### PR TITLE
v2: Scoring, onboarding, and PM2 improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ Minos (SN107) is a subnet for genomic variant calling and benchmarking powered b
 ```
 minos_subnet/
 ├── neurons/                  # Bittensor neuron entrypoints
-│   ├── validator.py          # Full validator orchestration
 │   ├── miner.py              # Miner loop: poll, download, call variants, submit config
+│   ├── validator.py          # Validator loop: subset scoring, set chain weights
 │   ├── status.py             # Health checks and system status
 │   └── README.md             # Neurons documentation
 ├── templates/                # Variant-calling tool templates
@@ -83,15 +83,19 @@ minos_subnet/
 │   ├── deepvariant.py        # Google DeepVariant template
 │   ├── freebayes.py          # FreeBayes template
 │   ├── bcftools.py           # BCFtools mpileup/call template
+│   ├── _common.py            # Shared template utilities
 │   └── tool_params.py        # Parameter definitions and validation
 ├── utils/                    # Genomics utility modules
-│   ├── scoring.py            # hap.py validation and scoring
-│   ├── weight_tracking.py    # EMA score tracking
-│   ├── file_utils.py         # File download and management
-│   ├── platform_client.py    # Platform API client for miners/validators
+│   ├── scoring.py            # hap.py Docker runner + AdvancedScorer
+│   ├── weight_tracking.py    # EMA score tracker + winner-takes-all weights
+│   ├── platform_client.py    # Authenticated API client (miner + validator)
+│   ├── subset_scoring.py     # Subset scoring helpers (assignments, deadlines)
+│   ├── config_loader.py      # Tool config file parser
+│   ├── path_utils.py         # Safe filesystem paths
+│   ├── file_utils.py         # SHA256-verified file download + caching
 │   └── README.md             # Utils documentation
 ├── base/                     # Core subnet config
-│   ├── genomics_config.py    # Genomics settings (Docker images, timeouts, EMA params)
+│   ├── genomics_config.py    # Central config (Docker images, timeouts, EMA params)
 │   └── s3_manifest.json      # Reference data paths (local + S3)
 ├── configs/                  # Miner-tunable quality parameters
 │   ├── gatk.conf
@@ -99,10 +103,15 @@ minos_subnet/
 │   ├── freebayes.conf
 │   └── bcftools.conf
 ├── docs/                     # Architecture and integration docs
-│   └── tuning_guide.md       # Miner tuning reference (scoring, parameters, strategy)
+│   ├── architecture.md       # System architecture deep dive
+│   ├── tuning_guide.md       # Miner tuning reference (scoring, parameters, strategy)
+│   └── hap_py_docker.md      # hap.py Docker image reference
 ├── scripts/                  # Developer tools
 │   ├── verify.sh             # Pre-flight environment check
 │   └── demo.sh               # End-to-end demo runner
+├── tests/                    # Unit and integration tests
+│   ├── conftest.py
+│   └── test_*.py             # Tests for scoring, config, platform client, etc.
 ├── install.sh                # Installer (full setup or update mode)
 ├── setup.py                  # Interactive setup wizard
 ├── start-miner.sh            # Start miner (with inline wallet setup)
@@ -111,6 +120,7 @@ minos_subnet/
 ├── pm2-validator.sh          # Start / restart validator under PM2 (wraps start-validator.sh)
 ├── ecosystem.miner.config.js # PM2 app config (miner)
 ├── ecosystem.validator.config.js # PM2 app config (validator)
+├── min_compute.yml           # Minimal compute requirements
 ├── requirements.txt          # Python dependencies
 ├── .env.miner.example        # Miner environment configuration
 ├── .env.validator.example    # Validator environment configuration

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ minos_subnet/
 | CPU/RAM (Validator) | ≥8 cores / 32 GB RAM | hap.py scoring benefits from cores |
 | CPU/RAM (Miner) | ≥4 cores / 8–16 GB RAM | 8 GB for BCFtools/FreeBayes, 16 GB for DeepVariant |
 | Disk | ≥60 GB (miner) / ≥100 GB (validator) | Reference data ~9 GB + temporary files |
-| Docker | 24.0+ | Required for GATK, hap.py, bcftools |
+| Docker | 20.10+ (24.0+ recommended) | Required for GATK, hap.py, bcftools |
 | Python | 3.10+ | We test on 3.12 |
 | Bittensor | Latest pip install | Provides wallet/subtensor/dendrite APIs |
 
@@ -149,8 +149,9 @@ minos_subnet/
 git clone https://github.com/minos-protocol/minos_subnet.git
 cd minos_subnet
 bash install.sh          # First-time: full setup (venv, deps, Docker, reference data, wallet)
-bash start-miner.sh      # Start as miner
-bash start-validator.sh  # Start as validator
+bash start-miner.sh      # Start as miner (choose one)
+# OR
+bash start-validator.sh  # Start as validator (choose one)
 ```
 
 The `start-*.sh` scripts handle wallet setup on first run — no manual `.env` editing needed. Run with `--help` to see all options, or `--setup` to re-run the setup wizard. If you already ran `install.sh` before, running it again will only update dependencies and download any new reference data (use `--fresh` to redo everything).
@@ -216,15 +217,17 @@ cp .env.validator.example .env # for validators
 docker pull broadinstitute/gatk:4.5.0.0
 docker pull google/deepvariant:1.5.0
 docker pull staphb/freebayes:1.3.7
-docker pull genonet/hap-py:0.3.15
+docker pull genonet/hap-py@sha256:03acabe84bbfba35f5a7234129d524c563f5657e1f21150a2ea2797f8e6d05f2
 docker pull quay.io/biocontainers/bcftools:1.20--h8b25389_0
 docker pull quay.io/biocontainers/samtools:1.20--h50ea8bc_0
 ```
 
-#### 4. Download Reference Data
+> **Note:** The hap.py image is pinned by SHA256 digest for reproducible scoring. The tag `genonet/hap-py:0.3.15` points to the same image but the digest is what validators use internally.
+
+#### 4. Run Setup Wizard
 
 ```bash
-# Downloads from our public S3 bucket (see base/s3_manifest.json for URLs)
+# Interactive wizard: configures wallet, downloads reference data, sets up .env
 python setup.py
 ```
 
@@ -370,12 +373,15 @@ Validators run each miner's tool config and score the resulting VCF from that ag
 
 ### EMA Weight Tracking
 
-Scores are smoothed over time using Exponential Moving Average:
+The raw AdvancedScorer output (0–100) is normalized to a 0–1 scale before feeding into the EMA. Scores are smoothed over time using Exponential Moving Average:
 
 ```python
+# AdvancedScorer returns 0-100, normalized to 0-1 for EMA
+combined_final = advanced_score / 100.0
 # EMA starts at 0; first round yields 10% of first score
-ema = (1 - alpha) * ema + alpha * raw_score
+ema = (1 - alpha) * ema + alpha * combined_final
 # alpha = 0.1 (10% weight on new scores)
+# Example: raw score 85/100 → combined_final 0.85 → EMA ~0.085 after first round
 ```
 
 ### Weight Distribution
@@ -405,11 +411,16 @@ In the warmup phase, miners with scores within 0.5% of each other are tiebroken 
 ### Logs
 
 ```bash
-# Validator logs
+# PM2 (recommended)
+pm2 logs minos-miner
+pm2 logs minos-validator
+
+# systemd (if using systemd service)
+journalctl -u minos-miner -f
 journalctl -u minos-validator -f
 
-# Miner logs
-journalctl -u minos-miner -f
+# Direct (if running manually)
+# Output streams to terminal
 ```
 
 ### Health Checks

--- a/README.md
+++ b/README.md
@@ -348,13 +348,17 @@ The Minos Platform is a hosted service at `https://api.theminos.ai` that handles
 
 ### Key Endpoints
 
-| Endpoint                      | Used by   |               Description                    |
-| ------------------------------|-----------|----------------------------------------------|
-| `POST /v2/round-status`       | Miner     | Poll for active rounds and presigned BAM URL |
-| `POST /v2/submit-config`      | Miner     | Submit variant-calling tool config           |
-| `POST /v2/get-scoring-rounds` | Validator | Fetch rounds ready for scoring               |
-| `POST /v2/get-submissions`    | Validator | Fetch all miner configs for a round          |
-| `POST /v2/submit-score`       | Validator | Submit per-miner scores                      |
+| Endpoint                         | Used by   | Description                                    |
+| ---------------------------------|-----------|------------------------------------------------|
+| `POST /v2/round-status`         | Miner     | Poll for active rounds and presigned BAM URL   |
+| `POST /v2/submit-config`        | Miner     | Submit variant-calling tool config             |
+| `POST /v2/get-scoring-rounds`   | Validator | Fetch rounds ready for scoring                 |
+| `POST /v2/get-submissions`      | Validator | Fetch all miner configs for a round            |
+| `POST /v2/get-assignment`       | Validator | Get primary/secondary miner scoring assignment |
+| `POST /v2/submit-score`         | Validator | Submit per-miner scores                        |
+| `POST /v2/get-backfill-scores`  | Validator | Fetch peer scores after scoring window closes  |
+| `POST /v2/submit-weight-history`| Validator | Submit EMA scores and weights after round      |
+| `POST /v2/get-validator-state`  | Validator | Recover EMA state after validator restart       |
 
 ---
 
@@ -427,7 +431,7 @@ journalctl -u minos-validator -f
 
 ```bash
 # Platform health
-curl <PLATFORM_URL>/health
+curl https://api.theminos.ai/health
 
 # Metagraph status
 btcli subnet metagraph --netuid 107

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ minos_subnet/
 │   ├── freebayes.conf
 │   └── bcftools.conf
 ├── docs/                     # Architecture and integration docs
+│   └── tuning_guide.md       # Miner tuning reference (scoring, parameters, strategy)
+├── scripts/                  # Developer tools
+│   ├── verify.sh             # Pre-flight environment check
+│   └── demo.sh               # End-to-end demo runner
 ├── install.sh                # Installer (full setup or update mode)
 ├── setup.py                  # Interactive setup wizard
 ├── start-miner.sh            # Start miner (with inline wallet setup)
@@ -415,7 +419,10 @@ btcli subnet metagraph --netuid 107
 - [neurons/README.md](neurons/README.md) - Detailed miner/validator documentation
 - [utils/README.md](utils/README.md) - Utility modules reference
 - [docs/architecture.md](docs/architecture.md) - System architecture deep dive
+- [docs/tuning_guide.md](docs/tuning_guide.md) - Miner tuning guide (scoring breakdown, parameters, strategy)
 - [docs/hap_py_docker.md](docs/hap_py_docker.md) - hap.py Docker image reference
+- [scripts/verify.sh](scripts/verify.sh) - Pre-flight environment check (`bash scripts/verify.sh --miner`)
+- [scripts/demo.sh](scripts/demo.sh) - Run a single demo round end-to-end (`bash scripts/demo.sh`)
 
 ---
 

--- a/base/__init__.py
+++ b/base/__init__.py
@@ -6,6 +6,7 @@ from .genomics_config import (
     MINER_CONFIG,
     BASE_DIR,
     is_docker_available,
+    require_docker,
 )
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "MINER_CONFIG",
     "BASE_DIR",
     "is_docker_available",
+    "require_docker",
 ]

--- a/base/genomics_config.py
+++ b/base/genomics_config.py
@@ -47,12 +47,38 @@ MINER_CONFIG = {
 def is_docker_available() -> bool:
     """Check if Docker is available and daemon is running."""
     try:
-        # Check docker is installed
         result = subprocess.run(["docker", "--version"], capture_output=True, timeout=5)
         if result.returncode != 0:
             return False
-        # Check daemon is running (docker info fails if daemon not running)
         result = subprocess.run(["docker", "info"], capture_output=True, timeout=10)
         return result.returncode == 0
     except (FileNotFoundError, subprocess.SubprocessError, OSError):
         return False
+
+
+def require_docker():
+    """Fail fast if Docker is not available. Call at miner/validator startup."""
+    try:
+        result = subprocess.run(["docker", "--version"], capture_output=True, timeout=5)
+        if result.returncode != 0:
+            raise RuntimeError(
+                "Docker is installed but returned an error. "
+                "Reinstall Docker: https://docs.docker.com/get-docker/"
+            )
+        result = subprocess.run(["docker", "info"], capture_output=True, timeout=10)
+        if result.returncode != 0:
+            raise RuntimeError(
+                "Docker daemon is not running. "
+                "Start Docker and try again."
+            )
+    except FileNotFoundError:
+        raise RuntimeError(
+            "Docker is required but not installed. "
+            "Minos uses Docker to run variant calling tools in reproducible containers. "
+            "Install Docker: https://docs.docker.com/get-docker/"
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(
+            "Docker is not responding (timed out). "
+            "Restart Docker and try again."
+        )

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ Minos is a Bittensor subnet (SN107) that creates a decentralised market for geno
 
 Genomic variant calling accuracy is critical for real-world genomics, yet benchmarking is fragmented and untrustworthy. Minos turns this into a continuous, incentivized benchmarking network:
 
-- **Miners** run any variant-calling pipeline they choose (GATK, DeepVariant, FreeBayes, BCFtools, or custom) and earn rewards proportional to their accuracy.
+- **Miners** run variant-calling pipelines (GATK, DeepVariant, FreeBayes, or BCFtools) and earn rewards proportional to their accuracy.
 - **Validators** re-run miner configurations against private hold-out data and score results with hap.py — no trust required.
 - **The platform** generates synthetic benchmark BAMs (GIAB + HelixForge-inserted mutations) and coordinates rounds.
 
@@ -90,7 +90,7 @@ All API calls are authenticated via canonical request signing. Each request incl
 | `gatk` | `broadinstitute/gatk:4.5.0.0` |
 | `deepvariant` | `google/deepvariant:1.5.0` |
 | `freebayes` | `staphb/freebayes:1.3.7` |
-| `bcftools` | `quay.io/biocontainers/bcftools:1.20` |
+| `bcftools` | `quay.io/biocontainers/bcftools:1.20--h8b25389_0` |
 
 Miners tune quality parameters via `configs/<tool>.conf`. Infrastructure parameters (`threads`, `memory_gb`, `timeout`, `ref_build`, `num_threads`) are stripped before submission and cannot influence scoring.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,20 +98,39 @@ Miners tune quality parameters via `configs/<tool>.conf`. Infrastructure paramet
 
 ## 5. Validator Loop
 
+Validators use **subset-based scoring** to scale across many miners. Instead of every validator scoring every miner (O(V×M)), the platform assigns each validator a primary miner range based on stake rank. Adjacent validators share a 20% overlap zone for integrity cross-checks.
+
 ```python
 while True:
-    rounds = get_scoring_rounds()          # poll platform for rounds in scoring phase
+    rounds = get_scoring_rounds()              # poll platform for rounds in scoring phase
     for round in rounds:
-        submissions = get_submissions(round)   # miner configs + presigned BAM/truth URLs
-        download_bam_and_truth(round)          # cached; skipped if SHA256 matches
-        for miner in submissions:
-            vcf = run_tool(miner.tool_config)  # reproduce miner's exact output
+        assignment = get_assignment(round)      # primary + secondary miner lists
+        submissions = get_submissions(round)    # miner configs + presigned BAM/truth URLs
+        download_bam_and_truth(round)           # cached; skipped if SHA256 matches
+
+        # Score primary miners first (no deadline pressure)
+        for miner in assignment.primary:
+            vcf = run_tool(miner.tool_config)
             metrics = score_with_happy(vcf, truth_vcf)
             score = compute_advanced_score(metrics)
             update_ema(miner.hotkey, score)
-        set_weights_on_chain()             # winner-takes-all by EMA
+
+        # Score secondary miners until 3 min before deadline
+        for miner in assignment.secondary:
+            if approaching_deadline():
+                break
+            # same scoring as above
+
+        # After scoring window closes: fetch peer scores for gap miners
+        backfill = get_backfill_scores(round)   # commit-then-reveal
+        for entry in backfill:
+            update_ema(entry.hotkey, entry.score)
+
+        set_weights_on_chain()                  # winner-takes-all by EMA
     sleep(query_interval)
 ```
+
+If the platform does not support assignments (e.g. single-validator testnet), the validator falls back to scoring all miners sequentially — identical to the pre-subset behavior.
 
 ### 5.1 Scoring formula
 
@@ -155,21 +174,25 @@ SNP/INDEL weighting is truth-count-proportional (fallback: 70/30).
 minos_subnet/
 ├── neurons/
 │   ├── miner.py           # Miner loop: poll, download, call variants, submit config
-│   ├── validator.py       # Validator loop: score submissions, set chain weights
-│   └── status.py          # Health checks and system status
+│   ├── validator.py       # Validator loop: subset scoring, set chain weights
+│   ├── status.py          # Health checks and system status
+│   └── README.md          # Neurons documentation
 ├── templates/
 │   ├── gatk.py            # GATK HaplotypeCaller template
 │   ├── deepvariant.py     # Google DeepVariant template
 │   ├── freebayes.py       # FreeBayes template
 │   ├── bcftools.py        # BCFtools mpileup/call template
+│   ├── _common.py         # Shared template utilities
 │   └── tool_params.py     # Parameter definitions and validation
 ├── utils/
 │   ├── scoring.py         # hap.py Docker runner + AdvancedScorer
 │   ├── weight_tracking.py # EMA score tracker + winner-takes-all weights
 │   ├── platform_client.py # Authenticated API client (miner + validator)
+│   ├── subset_scoring.py  # Subset scoring helpers (assignments, deadlines)
 │   ├── config_loader.py   # Tool config file parser
 │   ├── path_utils.py      # Safe filesystem paths
-│   └── file_utils.py      # SHA256-verified file download + caching
+│   ├── file_utils.py      # SHA256-verified file download + caching
+│   └── README.md          # Utils documentation
 ├── base/
 │   ├── genomics_config.py # Central config (Docker images, timeouts, EMA params)
 │   └── s3_manifest.json   # Reference data paths (local + S3)
@@ -178,8 +201,26 @@ minos_subnet/
 │   ├── deepvariant.conf   # Miner-tunable DeepVariant parameters
 │   ├── freebayes.conf     # Miner-tunable FreeBayes parameters
 │   └── bcftools.conf      # Miner-tunable BCFtools parameters
+├── docs/
+│   ├── architecture.md    # This document
+│   ├── tuning_guide.md    # Miner tuning reference (scoring, parameters, strategy)
+│   └── hap_py_docker.md   # hap.py Docker image reference
+├── scripts/
+│   ├── verify.sh          # Pre-flight environment check
+│   └── demo.sh            # End-to-end demo runner
+├── tests/                 # Unit and integration tests
+│   ├── conftest.py
+│   └── test_*.py          # Tests for scoring, config, platform client, etc.
 ├── install.sh             # Installer (full setup or update mode)
 ├── setup.py               # Interactive setup wizard
 ├── start-miner.sh         # Start miner (with inline wallet setup)
-└── start-validator.sh     # Start validator (with inline wallet setup)
+├── start-validator.sh     # Start validator (with inline wallet setup)
+├── pm2-miner.sh           # Start / restart miner under PM2
+├── pm2-validator.sh       # Start / restart validator under PM2
+├── ecosystem.miner.config.js     # PM2 config (miner)
+├── ecosystem.validator.config.js # PM2 config (validator)
+├── min_compute.yml        # Minimal compute requirements
+├── requirements.txt       # Python dependencies
+├── .env.miner.example     # Miner environment configuration
+└── .env.validator.example # Validator environment configuration
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,9 +50,10 @@ Key design choice: **miners submit configs, not VCFs**. Validators independently
 | Reference | GRCh38 FASTA + index + RTG SDF (chr1-chr22) | Public (downloaded by all) |
 | Benchmark BAM | GIAB donors (HG001-HG007) 100-300× per chromosome, downsampled | Public (via platform presigned URL) |
 | Truth VCF | GIAB + HelixForge-inserted synthetic mutations | Validators only (presigned URL, round-scoped) |
-| Confident BED | GIAB high-confidence regions per chromosome | Validators only (per-round) |
+| Mutations-only VCF | Synthetic mutations only (no GIAB variants) | Validators only (primary scoring scope) |
+| Confident BED | GIAB high-confidence regions per chromosome | Validators only (fallback scoring scope) |
 
-Synthetic mutations are injected by the platform using HelixForge into known positions, creating a merged truth (`GIAB ∪ synthetic variants`) that miners cannot pre-compute answers for.
+Synthetic mutations are injected by the platform using HelixForge into known positions. Validators score miner output against the **mutations-only VCF** (synthetic variants only) as the primary evaluation scope. The confident BED path serves as a fallback when the mutations-only VCF is unavailable.
 
 ---
 

--- a/docs/hap_py_docker.md
+++ b/docs/hap_py_docker.md
@@ -2,6 +2,8 @@
 
 This document describes the custom `genonet/hap-py:0.3.15` Docker image used for VCF benchmarking in the validator scoring pipeline.
 
+> **Note:** The validator code pins this image by SHA256 digest (`genonet/hap-py@sha256:03acabe84bb...`) for reproducible scoring. The tag `:0.3.15` points to the same image and is used in this doc for readability.
+
 ---
 
 ## Why a Custom Image?

--- a/docs/tuning_guide.md
+++ b/docs/tuning_guide.md
@@ -27,11 +27,12 @@ Validators compare your VCF output against a truth VCF using **hap.py** (the GA4
 
 ### EMA Smoothing and Winner-Takes-All
 
-Your per-round score is smoothed with an exponential moving average (alpha = 0.1). This means:
+The AdvancedScorer outputs a raw score on a 0–100 scale. This is normalized to 0–1 before feeding into the EMA (so a raw score of 85/100 becomes 0.85 in EMA). Your EMA is smoothed with alpha = 0.1:
 
 - A single bad round does not destroy you, but persistent low scores will drag your EMA down.
 - It takes roughly 10 rounds for the EMA to mostly reflect your current performance.
 - Missing rounds applies a decay factor of 0.95 per missed round to your EMA.
+- When reading logs: `Score: 85.00/100  EMA: 0.8500` — the score is 0–100, the EMA is 0–1.
 
 **Warmup phase** (until any miner has participated in 10+ rounds): rewards are split among the top 3 miners by EMA — 50% to 1st, 30% to 2nd, 20% to 3rd.
 

--- a/docs/tuning_guide.md
+++ b/docs/tuning_guide.md
@@ -1,0 +1,224 @@
+# Minos (SN107) Miner Tuning Guide
+
+Practical guide to maximizing your variant-calling scores on Bittensor Subnet 107.
+
+---
+
+## 1. How Scoring Works
+
+Validators compare your VCF output against a truth VCF using **hap.py** (the GA4GH benchmarking tool). Your raw metrics feed into the **AdvancedScorer**, which produces a score from 0 to 100.
+
+### AdvancedScorer Breakdown
+
+| Component    | Weight | What It Measures                                          |
+|--------------|--------|-----------------------------------------------------------|
+| Core F1      | 60%    | Truth-weighted F1 score (emphasis gamma = 0.5)            |
+| Completeness | 15%    | Recall + coverage (emphasis gamma = 3.0)                  |
+| FP Rate      | 15%    | Penalizes false positive rate above a dynamic threshold   |
+| Quality      | 10%    | Ti/Tv ratio and Het/Hom ratio deviation penalties         |
+
+**Core F1** dominates. Get your precision and recall right first; everything else is refinement.
+
+**FP Rate** uses a dynamic threshold based on truth set size (typically ~0.2-1.0%). The penalty is an exponential decay — exceeding the threshold does not instantly zero your score, but it ramps quickly. Calling too aggressively will hurt you here.
+
+**Completeness** rewards finding more true variants. Over-filtering to reduce FPs will cost you here — it is a balancing act.
+
+**Quality** checks biological plausibility. For WGS data, Ti/Tv should be around 2.0 and Het/Hom around 1.5. Large deviations indicate systematic errors in your calls.
+
+### EMA Smoothing and Winner-Takes-All
+
+Your per-round score is smoothed with an exponential moving average (alpha = 0.1). This means:
+
+- A single bad round does not destroy you, but persistent low scores will drag your EMA down.
+- It takes roughly 10 rounds for the EMA to mostly reflect your current performance.
+- Missing rounds applies a decay factor of 0.95 per missed round to your EMA.
+
+**Warmup phase** (until any miner has participated in 10+ rounds): rewards are split among the top 3 miners by EMA — 50% to 1st, 30% to 2nd, 20% to 3rd.
+
+**Normal phase** (after warmup): **winner-takes-all** — the miner with the highest EMA gets 100% of emissions for that validator. Second place gets nothing.
+
+Consistency matters as much as peak performance.
+
+---
+
+## 2. Choosing Your Variant Caller
+
+Four tools are supported. Pick based on your hardware and willingness to tune.
+
+| Tool                  | Accuracy | Speed   | Tunability | Best For                        |
+|-----------------------|----------|---------|------------|---------------------------------|
+| GATK HaplotypeCaller  | Highest  | Slowest | Most knobs | Maximizing score, if you have time to tune |
+| DeepVariant           | High     | Medium  | Few knobs  | Consistent high scores with minimal tuning |
+| FreeBayes             | Good     | Medium  | Moderate   | Good balance of speed and accuracy |
+| bcftools mpileup      | Lower    | Fastest | Moderate   | Quick testing, low-resource setups |
+
+**Recommendation:** Start with DeepVariant if you want reliable scores fast. Move to GATK if you want to squeeze out every point and are willing to iterate.
+
+---
+
+## 3. Key Parameters for Each Tool
+
+Only quality-related parameters are exposed. Infrastructure params (threads, memory) are handled by the system and stripped before submission.
+
+### GATK HaplotypeCaller
+
+| Parameter | Default | Range | Effect |
+|-----------|---------|-------|--------|
+| `standard_min_confidence_threshold_for_calling` | 30 | 0-100 | Higher = fewer, more confident calls. Raising this reduces FPs but hurts recall. |
+| `min_base_quality_score` | 10 | 0-50 | Filters bases below this quality. Too high kills soft evidence for real variants. |
+| `pcr_indel_model` | CONSERVATIVE | NONE, HOSTILE, AGGRESSIVE, CONSERVATIVE | Use **NONE** for PCR-free libraries (GIAB donors are PCR-free). |
+
+**Tuning priority:** Set `pcr_indel_model=NONE` first. Then adjust `standard_min_confidence_threshold_for_calling` between 20-40 to find your sweet spot between precision and recall.
+
+### DeepVariant
+
+| Parameter             | Default | Effect                                                                |
+|-----------------------|---------|-----------------------------------------------------------------------|
+| `model_type`          | WGS     | Must be **WGS** for Minos BAMs. Using WES will produce wrong results. |
+| `min_mapping_quality` | 5       | Filters reads with mapping quality below this.                        |
+
+DeepVariant is intentionally less tunable — it relies on its trained model. Your main lever is `min_mapping_quality`. The defaults are generally strong.
+
+### FreeBayes
+
+| Parameter                | Default | Effect                                                                         |
+|--------------------------|---------|--------------------------------------------------------------------------------|
+| `min_alternate_fraction` | 0.05    | Minimum variant allele frequency to call. Lower = more sensitive but more FPs. |
+| `min_mapping_quality`    | 1       | Filter poorly mapped reads. Consider raising to 10-20.                         |
+
+**Tuning priority:** `min_alternate_fraction` is your main lever. The default 0.05 is sensitive — raise toward 0.1-0.2 if your FP rate is too high, or keep it low if completeness is suffering.
+
+### bcftools mpileup
+
+| Parameter | Default | Effect |
+|-----------|---------|--------|
+| `min_MQ` | 0 | Mapping quality filter. Raise to 10-20 for cleaner calls. |
+| `min_BQ` | 13 | Base quality filter. |
+
+bcftools is fast but generally scores lower. Good for testing your pipeline before switching to a more competitive caller.
+
+---
+
+## 4. Tuning Strategy
+
+### Step 1: Start with Defaults
+
+The defaults are tuned for GIAB-style WGS data, which is exactly what Minos uses. Run a few rounds with stock settings to establish your baseline.
+
+### Step 2: Read Your Scores
+
+Look at which component is dragging you down:
+
+- **Low Core F1?** Your precision or recall is off. Check base quality and confidence thresholds.
+- **Low Completeness?** You are filtering too aggressively. Lower your quality thresholds.
+- **High FP penalty?** You are calling too many false variants. Raise confidence thresholds or mapping quality filters.
+- **Low Quality score?** Your Ti/Tv or Het/Hom ratios are off. This usually indicates systematic issues — check that your model_type and PCR settings are correct before touching other params.
+
+### Step 3: Adjust One Parameter at a Time
+
+Change one parameter, run a round, compare. Changing multiple parameters at once makes it impossible to know what helped.
+
+### Step 4: Watch the FP Threshold
+
+The FP rate penalty ramps steeply once you exceed the dynamic threshold. If your FP component is low, prioritize reducing false positives over marginal recall improvements. The 15% FP weight makes this penalty expensive.
+
+### Step 5: Test Locally First
+
+Use demo mode to run test jobs locally before committing to live rounds. A bad config can tank your EMA for 10+ rounds due to the smoothing.
+
+### The Core Tradeoff
+
+```
+More aggressive calling → Higher recall → Better completeness
+                        → More false positives → Worse FP penalty
+
+More conservative calling → Higher precision → Better FP rate
+                          → Lower recall → Worse completeness
+```
+
+The scoring weights (60% F1, 15% completeness, 15% FP) mean you want to lean slightly toward precision, but not so far that completeness drops significantly.
+
+---
+
+## 5. Score Ranges
+
+| Range   | Interpretation                                                    |
+|---------|-------------------------------------------------------------------|
+| 80-95+  | Competitive. You are in contention for winner-takes-all.          |
+| 60-80   | Solid baseline. Targeted parameter tuning can push you higher.    |
+| 40-60   | Something is suboptimal. Check tool parameters and Docker image.  |
+| Below 40| Likely a configuration error. See Common Mistakes below.          |
+
+The genomic region (chr20, 5MB windows from 10MB-55MB) varies per round, so some score variance is normal. Focus on your EMA trend, not individual rounds.
+
+---
+
+## 6. Common Mistakes
+
+**Wrong model_type in DeepVariant.** Using `WES` instead of `WGS` will silently produce worse calls. Minos BAMs are whole-genome. Always use `WGS`.
+
+**Over-filtering.** Setting `min_base_quality_score` to 30+ or `standard_min_confidence_threshold_for_calling` to 50+ will kill your recall. The completeness penalty (15%) will eat your score. Start conservative with thresholds and only raise them if your FP rate is clearly too high.
+
+**Not using PCR-free mode for GATK.** GIAB donors use PCR-free library prep. Running GATK with the default `CONSERVATIVE` PCR indel model introduces unnecessary indel filtering. Set `pcr_indel_model=NONE`.
+
+**Timeout from too few threads.** While you cannot control thread count directly (it is an infrastructure parameter), make sure your Docker environment has enough resources. If your job times out before the submission window closes, you get a zero for that round — devastating for your EMA.
+
+**Ignoring Ti/Tv ratio.** A Ti/Tv ratio significantly below 2.0 for WGS usually means you are calling many false SNPs. Check your quality filters rather than accepting a low Quality component score.
+
+**Changing too many parameters at once.** With EMA smoothing at alpha=0.1, it takes many rounds to see the true effect of changes. Methodical single-parameter tuning is the only reliable approach.
+
+---
+
+## 7. Quick Reference: Config Files
+
+Config files live in your miner's `configs/` directory:
+
+```
+configs/gatk.conf
+configs/deepvariant.conf
+configs/freebayes.conf
+configs/bcftools.conf
+```
+
+### Format
+
+```ini
+# Lines starting with # are comments
+standard_min_confidence_threshold_for_calling=30
+min_base_quality_score=10
+pcr_indel_model=NONE
+```
+
+One key=value pair per line. Only quality parameters are accepted — infrastructure parameters (threads, memory, tmp directories) are managed by the system and will be stripped if included.
+
+### Minimal Competitive Configs
+
+**GATK (recommended starting point):**
+```ini
+standard_min_confidence_threshold_for_calling=30
+min_base_quality_score=10
+pcr_indel_model=NONE
+```
+
+**DeepVariant:**
+```ini
+model_type=WGS
+min_mapping_quality=10
+```
+
+**FreeBayes:**
+```ini
+min_alternate_fraction=0.05
+min_mapping_quality=1
+```
+
+---
+
+## Summary
+
+1. Pick your tool (DeepVariant for ease, GATK for max score).
+2. Start with defaults.
+3. Set PCR-free mode if using GATK.
+4. Tune one parameter at a time, watching your per-component scores.
+5. Keep your FP rate low — the penalty ramps steeply past the threshold.
+6. Be patient — EMA smoothing means results take rounds to stabilize.

--- a/ecosystem.miner.config.js
+++ b/ecosystem.miner.config.js
@@ -13,7 +13,11 @@ module.exports = {
       autorestart: true,
       max_restarts: 10,
       restart_delay: 30000,
+      kill_timeout: 15000,
       log_date_format: "YYYY-MM-DD HH:mm:ss Z",
+      env: {
+        PYTHONUNBUFFERED: "1",
+      },
     },
   ],
 };

--- a/ecosystem.validator.config.js
+++ b/ecosystem.validator.config.js
@@ -13,7 +13,11 @@ module.exports = {
       autorestart: true,
       max_restarts: 10,
       restart_delay: 30000,
+      kill_timeout: 15000,
       log_date_format: "YYYY-MM-DD HH:mm:ss Z",
+      env: {
+        PYTHONUNBUFFERED: "1",
+      },
     },
   ],
 };

--- a/neurons/README.md
+++ b/neurons/README.md
@@ -20,8 +20,9 @@ A miner receives genomic data (DNA sequencing files) and finds genetic variants 
 ### How It Works
 
 1. **Start Up**
+   - Docker availability is verified (fails fast with actionable error if missing)
    - Connect to the Bittensor network
-   - Register your hotkey to get a unique ID
+   - Register your hotkey to get a unique ID (or run in demo mode without registration)
    - Connect to the Minos Platform API to poll for available scoring rounds
 
 2. **Receive a Task**
@@ -102,13 +103,16 @@ A validator uses miners config file and selected hyperparameters to run the vari
    - Load reference genomic data
    - Connect to Minos Platform (authenticated via keypair signature)
 
-2. **Run and Score the Results**
+2. **Run and Score the Results** (subset-based scoring)
+   - Fetch scoring assignment from platform (primary miner range based on validator stake)
+   - Score primary miners first (no deadline pressure)
+   - Score secondary miners for gap coverage until 3 min before deadline
    - Re-run each miner's tool config locally (trustless verification)
    - Run hap.py to compare against known truth
    - Calculate quality scores for SNPs and INDELs
-   - Compute advanced score that will be used to assign the weights to the blockchain
 
-3. **Update Weights**
+3. **Backfill and Update Weights**
+   - After scoring window closes, fetch peer scores for miners not personally covered
    - Track scores with EMA (exponential moving average)
    - Winner-takes-all: best eligible miner gets 100% weight
    - Submit weights to Bittensor blockchain
@@ -235,7 +239,7 @@ Weights are assigned in two phases:
 ### Validator Needs
 
 - Reference genomic data (~9GB for chr1-chr22)
-- hap.py Docker image: `genonet/hap-py:0.3.15`
+- hap.py Docker image: `genonet/hap-py` (SHA256-pinned for reproducibility)
 - bcftools/samtools Docker images
 - 100GB+ storage for datasets and temporary files
 - 32GB+ RAM
@@ -258,8 +262,19 @@ Weights are assigned in two phases:
 | Platform 409 error | Round not in scoring phase | Check that the round is in the scoring window |
 | No miners available | Empty metagraph | Wait for miners to register |
 
+## Demo Mode
+
+The platform runs in **demo mode** before going live. In demo mode:
+- Registration is **not required** — anyone can test their setup
+- Variant calling runs normally on a sample BAM file
+- Submission is disabled (scores are not recorded)
+- A "DEMO COMPLETE" message confirms your system is ready
+
+Use `bash scripts/verify.sh --miner` to check prerequisites, or `bash scripts/demo.sh` to run a full end-to-end demo round.
+
 ## Learn More
 
+- [docs/tuning_guide.md](../docs/tuning_guide.md) — Parameter tuning, scoring breakdown, strategy
 - See `utils/` folder for genomics processing tools
 - See `base/` folder for configuration options
 - Check [main README](../README.md) for full documentation

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -28,7 +28,7 @@ if not hasattr(bt, "wallet"):
 if not hasattr(bt, "config"):
     bt.config = bt.Config
 
-from base import GENOMICS_CONFIG, MINER_CONFIG, is_docker_available, BASE_DIR
+from base import GENOMICS_CONFIG, MINER_CONFIG, is_docker_available, require_docker, BASE_DIR
 from utils.file_utils import download_file_verified, download_file_with_fallback
 from utils.platform_client import MinerPlatformClient, PlatformConfig, PlatformClientError
 from utils.config_loader import extract_tool_options, get_tool_version
@@ -60,6 +60,12 @@ class Miner:
         bt.logging.set_trace(self.config.logging.trace)
         bt.logging.set_debug(self.config.logging.debug)
 
+        try:
+            require_docker()
+        except RuntimeError as e:
+            bt.logging.error(str(e))
+            sys.exit(1)
+
         self.wallet = bt.wallet(config=self.config)
         bt.logging.info(f"Wallet loaded: {self.wallet.hotkey.ss58_address}")
 
@@ -80,7 +86,10 @@ class Miner:
                 "Miner not registered on subnet 107. "
                 "Register with: btcli subnets register --netuid 107 --wallet.name miner --wallet.hotkey default"
             )
-            bt.logging.info("Continuing in demo/unregistered mode — variant calling will still run")
+            bt.logging.info(
+                "Running in DEMO MODE — you can test variant calling without registration. "
+                "To participate in live rounds and earn TAO, register first."
+            )
 
         self.setup_variant_caller()
         self.setup_platform_client()
@@ -134,11 +143,7 @@ class Miner:
             sys.exit(1)
 
     def setup_variant_caller(self):
-        """Setup variant caller from MINER_TEMPLATE env var. Docker is required."""
-        if not is_docker_available():
-            bt.logging.error("Docker is required but not available. Please install Docker and try again.")
-            sys.exit(1)
-
+        """Setup variant caller from MINER_TEMPLATE env var."""
         self.variant_caller = os.getenv("MINER_TEMPLATE", "").lower() or MINER_CONFIG.get("default_caller", "gatk")
 
         # Validate template exists
@@ -324,10 +329,19 @@ class Miner:
 
         except PlatformClientError as e:
             bt.logging.warning(f"Round error: {e}")
-            # In demo mode, submission is blocked — don't retry the same round
             if "demo mode" in str(e).lower():
                 self.submitted_rounds.add(round_id)
-                print("   Demo mode — variant calling complete. Submission disabled.", flush=True)
+                print(f"\n{'='*60}", flush=True)
+                print(f"   DEMO COMPLETE", flush=True)
+                print(f"   Variant calling finished successfully!", flush=True)
+                print(f"   Your system is ready to mine on Subnet 107.", flush=True)
+                print(f"", flush=True)
+                print(f"   Submission is disabled because the network is in", flush=True)
+                print(f"   demo mode. When the network goes live, submissions", flush=True)
+                print(f"   will be automatic — no code changes needed.", flush=True)
+                print(f"", flush=True)
+                print(f"   Next: register your hotkey to earn TAO when live.", flush=True)
+                print(f"{'='*60}", flush=True)
             return False
         except Exception as e:
             bt.logging.error(f"Error processing round: {e}")

--- a/neurons/status.py
+++ b/neurons/status.py
@@ -58,7 +58,7 @@ MINER_DOCKER_IMAGES = {
 }
 
 VALIDATOR_DOCKER_IMAGES = [
-    "genonet/hap-py:0.3.15",
+    "genonet/hap-py@sha256:03acabe84bbfba35f5a7234129d524c563f5657e1f21150a2ea2797f8e6d05f2",
     "broadinstitute/gatk:4.5.0.0",
     "google/deepvariant:1.5.0",
     "staphb/freebayes:1.3.7",

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -16,7 +16,7 @@ import bittensor as bt
 import argparse
 import numpy as np
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from dotenv import load_dotenv
 
 # Bittensor v9/v10 compatibility — v10 removed lowercase aliases
@@ -27,7 +27,7 @@ if not hasattr(bt, "wallet"):
 if not hasattr(bt, "config"):
     bt.config = bt.Config
 
-from base import GENOMICS_CONFIG, VALIDATOR_CONFIG, is_docker_available, BASE_DIR
+from base import GENOMICS_CONFIG, VALIDATOR_CONFIG, is_docker_available, require_docker, BASE_DIR
 from utils import (
     HappyScorer,
     ScoreTracker,
@@ -38,6 +38,7 @@ from utils.file_utils import compute_sha256
 from utils.file_utils import download_file_with_fallback
 from utils.path_utils import safe_round_dir_name
 from utils.platform_client import ValidatorPlatformClient, PlatformConfig, PlatformClientError
+from utils.subset_scoring import should_stop_secondary_scoring
 from templates import load_template
 from templates.tool_params import validate_round_id
 
@@ -64,6 +65,12 @@ class Validator:
         bt.logging.info("Setting up validator...")
         bt.logging.set_trace(self.config.logging.trace)
         bt.logging.set_debug(self.config.logging.debug)
+
+        try:
+            require_docker()
+        except RuntimeError as e:
+            bt.logging.error(str(e))
+            sys.exit(1)
 
         bt.logging.info(f"Loading wallet: {self.config.wallet.name}/{self.config.wallet.hotkey}")
         self.wallet = bt.wallet(config=self.config)
@@ -325,14 +332,50 @@ class Validator:
             return {"next_scoring_window_start": None}
 
     async def _score_round_submissions(self, round_id: str):
-        """Score all submissions for a single round."""
+        """Score submissions for a single round using subset-based assignment.
+
+        Flow:
+        1. Fetch scoring assignment from platform (primary range + secondary order).
+        2. Download shared BAM + truth VCF once.
+        3. Score primary miners in assignment order (no deadline pressure).
+        4. Score secondary miners until 3 min before scoring deadline.
+        5. After deadline, fetch backfill scores for gap miners from platform.
+        6. Feed backfill scores into ScoreTracker, then record_round + set weights.
+        """
         rid_check = validate_round_id(round_id)
         if not rid_check["valid"]:
             bt.logging.error(f"_score_round_submissions: invalid round_id '{round_id}': {rid_check['error']}")
             return
 
         try:
-            # 2. Get all submissions for this round (includes presigned URLs)
+            # --- Step 1: Fetch assignment from platform ---
+            assignment = None
+            primary_hotkeys = set()
+            secondary_hotkeys_ordered = []
+            scoring_deadline = None
+
+            try:
+                assignment = await self.platform_client.get_assignment(round_id)
+                primary_hotkeys = set(assignment.get("primary_miner_hotkeys", []))
+                secondary_hotkeys_ordered = assignment.get("secondary_miner_hotkeys", [])
+                deadline_str = assignment.get("scoring_deadline")
+                if deadline_str:
+                    scoring_deadline = datetime.fromisoformat(
+                        deadline_str.replace("Z", "+00:00")
+                    )
+                bt.logging.info(
+                    f"Round {round_id}: assignment received — "
+                    f"primary={len(primary_hotkeys)} miners, "
+                    f"secondary={len(secondary_hotkeys_ordered)} miners"
+                )
+            except PlatformClientError as e:
+                bt.logging.warning(
+                    f"Round {round_id}: failed to get assignment ({e}). "
+                    f"Falling back to scoring all miners."
+                )
+                # Graceful fallback: score all miners as before (e.g. single-validator setup)
+
+            # --- Step 2: Get all submissions + download shared files ---
             round_data = await self.platform_client.get_round_submissions(round_id)
 
             submissions = round_data.get("submissions", [])
@@ -342,7 +385,6 @@ class Validator:
                 bt.logging.info(f"Round {round_id}: no submissions")
                 return
 
-            # 3. Download BAM and truth VCF, verify reference exists
             download_result = self._download_round_files(round_id, round_data)
             if download_result is None:
                 return
@@ -355,11 +397,11 @@ class Validator:
             ref_sdf_path = download_result["ref_sdf_path"]
             truth_bed_path = download_result["truth_bed_path"]
 
-            # 4. For each submission, run their tool config and score
-            scored_hotkeys = []  # Track which miners were scored this round
-            submission_times = {}  # hotkey -> submitted_at epoch for tiebreaking
+            # --- Step 3 & 4: Order submissions and score ---
+            scored_hotkeys = []
+            submission_times = {}
 
-            # Restart recovery: get miners already scored by this validator
+            # Restart recovery: restore already-scored miners
             already_scored = round_data.get("scored_miners") or {}
             if already_scored:
                 print(f"   Restart recovery: {len(already_scored)} miners already scored, skipping", flush=True)
@@ -369,7 +411,32 @@ class Validator:
                     scored_hotkeys.append(hotkey)
                     bt.logging.info(f"Restored score for {hotkey[:16]}...: combined_final={combined_final}")
 
-            for sub in submissions:
+            # Build ordered list: primary submissions first, then secondary
+            secondary_subs = []
+            if primary_hotkeys:
+                secondary_order_map = {hk: i for i, hk in enumerate(secondary_hotkeys_ordered)}
+                primary_subs = [s for s in submissions if s.get("miner_hotkey") in primary_hotkeys]
+                secondary_subs = [s for s in submissions if s.get("miner_hotkey") not in primary_hotkeys]
+                secondary_subs.sort(
+                    key=lambda s: secondary_order_map.get(s.get("miner_hotkey", ""), 999999)
+                )
+                ordered_subs = primary_subs + secondary_subs
+            else:
+                # No assignment (fallback mode) — score all in original order
+                ordered_subs = submissions
+
+            for sub in ordered_subs:
+                miner_hotkey = sub.get("miner_hotkey", "")
+                is_secondary = bool(primary_hotkeys) and miner_hotkey not in primary_hotkeys
+
+                # Stop secondary scoring when approaching deadline
+                if is_secondary and should_stop_secondary_scoring(scoring_deadline, buffer_seconds=180):
+                    bt.logging.info(
+                        f"Round {round_id}: approaching deadline — "
+                        f"stopping secondary scoring, {len(secondary_subs)} secondary miners remaining"
+                    )
+                    break
+
                 await self._score_single_miner(
                     round_id, sub, already_scored, work_dir, bam_path,
                     ref_path, ref_sdf_path, truth_bed_path, truth_vcf_path,
@@ -377,8 +444,10 @@ class Validator:
                     mutations_vcf_path=mutations_vcf_path,
                 )
 
-            # 9-10. Record round, set weights, cleanup
-            await self._finalize_round_scores(round_id, scored_hotkeys, submission_times)
+            # --- Steps 5 & 6: Backfill + finalize ---
+            await self._finalize_round_scores(
+                round_id, scored_hotkeys, submission_times, scoring_deadline
+            )
 
         except Exception as e:
             bt.logging.error(f"Error scoring round {round_id}: {e}")
@@ -691,14 +760,107 @@ class Validator:
             self.score_tracker.update(miner_hotkey, 0.0)
             scored_hotkeys.append(miner_hotkey)
 
-    async def _finalize_round_scores(self, round_id, scored_hotkeys, submission_times):
-        """Record round participation, set weights, and log completion."""
-        # 9. Record round participation for eligibility tracking
-        if scored_hotkeys:
-            self.score_tracker.record_round(round_id, scored_hotkeys)
-            bt.logging.info(f"Round {round_id}: recorded participation for {len(scored_hotkeys)} miners")
+    async def _finalize_round_scores(
+        self,
+        round_id: str,
+        scored_hotkeys: list,
+        submission_times: dict,
+        scoring_deadline=None,
+    ):
+        """Backfill gap miners from platform, record participation, then set weights.
 
-        # 10. Compute winner-takes-all weights and set on chain
+        Order matters:
+        1. Wait for scoring window to close (commit-then-reveal gate).
+        2. Fetch backfill scores for miners not personally covered.
+        3. Feed each backfill score into ScoreTracker.update().
+        4. Call record_round() ONCE with the complete set (personal + backfill).
+        5. Set chain weights from the full EMA state.
+        """
+        # --- Step 1: Wait for scoring window to close ---
+        if scoring_deadline is not None:
+            now = datetime.now(timezone.utc)
+            # Ensure deadline is tz-aware
+            if scoring_deadline.tzinfo is None:
+                scoring_deadline = scoring_deadline.replace(tzinfo=timezone.utc)
+            wait_secs = (scoring_deadline - now).total_seconds()
+            if wait_secs > 0:
+                bt.logging.info(
+                    f"Round {round_id}: waiting {wait_secs:.0f}s for scoring window to close "
+                    f"before fetching backfill scores"
+                )
+                await asyncio.sleep(wait_secs + 5)
+
+        # --- Step 2: Fetch backfill scores from platform ---
+        # Build the complete set of hotkeys (personal + backfill) before calling
+        # record_round() so decay is applied correctly to truly absent miners only.
+        all_scored_hotkeys = list(dict.fromkeys(scored_hotkeys))  # deduplicated, ordered
+
+        if self.platform_client:
+            try:
+                backfill_response = await self.platform_client.get_backfill_scores(
+                    round_id=round_id,
+                    scored_miner_hotkeys=all_scored_hotkeys,
+                )
+
+                backfill_scores = backfill_response.get("backfill_scores", [])
+                overlap_deltas = backfill_response.get("overlap_deltas", [])
+                unscored = backfill_response.get("unscored_miner_hotkeys", [])
+
+                # --- Step 3: Feed backfill into ScoreTracker ---
+                for entry in backfill_scores:
+                    hk = entry.get("miner_hotkey")
+                    combined_final = entry.get("combined_final", 0.0)
+                    if hk and hk not in set(all_scored_hotkeys):
+                        self.score_tracker.update(hk, combined_final)
+                        all_scored_hotkeys.append(hk)
+                        # Capture submitted_at for tiebreaking
+                        submitted_at = entry.get("submitted_at")
+                        if submitted_at and hk not in submission_times:
+                            try:
+                                submission_times[hk] = datetime.fromisoformat(
+                                    submitted_at.replace("Z", "+00:00")
+                                ).timestamp()
+                            except (ValueError, TypeError):
+                                submission_times[hk] = float("inf")
+
+                        source = entry.get("primary_validator_hotkey", "?")
+                        bt.logging.info(
+                            f"Backfilled {hk[:16]}...: combined_final={combined_final:.4f} "
+                            f"(from {source[:16]}...)"
+                        )
+
+                if backfill_scores:
+                    bt.logging.info(
+                        f"Round {round_id}: backfilled {len(backfill_scores)} miners, "
+                        f"{len(unscored)} miners had no score from any validator"
+                    )
+
+                # Log overlap integrity warnings
+                for delta_entry in overlap_deltas:
+                    delta = delta_entry.get("delta")
+                    if delta is not None and delta > 0.05:
+                        bt.logging.warning(
+                            f"Overlap integrity warning: miner {delta_entry.get('miner_hotkey', '')[:16]}... "
+                            f"delta={delta:.4f} vs peer {delta_entry.get('peer_validator_hotkey', '')[:16]}..."
+                        )
+
+            except PlatformClientError as e:
+                bt.logging.warning(
+                    f"Round {round_id}: backfill fetch failed ({e}). "
+                    f"Proceeding with partial scores — unscored miners will decay normally."
+                )
+
+        # --- Step 4: Record round with COMPLETE hotkey set ---
+        # This must happen after backfill so decay is only applied to miners
+        # with genuinely no score this round (not just ones we didn't cover).
+        if all_scored_hotkeys:
+            self.score_tracker.record_round(round_id, all_scored_hotkeys)
+            bt.logging.info(
+                f"Round {round_id}: recorded participation for {len(all_scored_hotkeys)} miners "
+                f"({len(scored_hotkeys)} personal + {len(all_scored_hotkeys) - len(scored_hotkeys)} backfill)"
+            )
+
+        # --- Step 5: Set chain weights ---
         await self._set_weights_after_round(round_id, submission_times)
 
         print(f"\n   Round {round_id} scoring complete", flush=True)

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -1000,7 +1000,7 @@ class Validator:
             return None
 
     async def _set_weights_after_round(self, round_id: str, submission_times: dict = None):
-        """Compute winner-takes-all weights, set on chain, and POST history to platform.
+        """Compute weight distribution, set on chain, and POST history to platform.
 
         Called after all miners in a round have been scored and EMA updated.
 
@@ -1029,24 +1029,27 @@ class Validator:
                 bt.logging.warning("No miners found for weight setting")
                 return
 
-            # Compute winner-takes-all weights
+            # Compute weight distribution
             weights = self.score_tracker.get_winner_takes_all_weights(
                 miner_hotkeys, submission_times
             )
 
-            # Log weight distribution
+            # Log weight distribution (mode-aware)
             stats = self.score_tracker.get_stats()
-            winner = [hk for hk, w in weights.items() if w > 0]
-            print(f"\n   Weight distribution (winner-takes-all):", flush=True)
+            recipients = [hk for hk, w in weights.items() if w > 0]
+            is_warmup = stats['eligible_count'] == 0
+            mode_label = "warmup split" if is_warmup else "winner-takes-all"
+            print(f"\n   Weight distribution ({mode_label}):", flush=True)
             print(f"   Eligible: {stats['eligible_count']}/{len(miner_hotkeys)} miners "
                   f"(need {stats['min_rounds_required']} rounds)", flush=True)
-            if winner:
-                w_hk = winner[0]
-                w_ema = self.score_tracker.ema_scores.get(w_hk, 0)
-                w_uid = hotkey_to_uid.get(w_hk, "?")
-                print(f"   Winner: UID {w_uid} ({w_hk[:16]}...) EMA={w_ema:.4f}", flush=True)
+            if recipients:
+                for r_hk in recipients:
+                    r_w = weights[r_hk]
+                    r_ema = self.score_tracker.ema_scores.get(r_hk, 0)
+                    r_uid = hotkey_to_uid.get(r_hk, "?")
+                    print(f"   UID {r_uid} ({r_hk[:16]}...) EMA={r_ema:.4f} weight={r_w:.2f}", flush=True)
             else:
-                print(f"   No winner — weights submission skipped (fail-closed)", flush=True)
+                print(f"   No recipients — weights submission skipped (fail-closed)", flush=True)
 
             # Set weights on chain (blocking RPC — run in thread to avoid blocking event loop)
             loop = asyncio.get_running_loop()
@@ -1072,7 +1075,7 @@ class Validator:
             bt.logging.error(traceback.format_exc())
 
     def set_weights(self, weights_by_hotkey: dict = None, hotkey_to_uid: dict = None, retry_count: int = 0):
-        """Set weights on the blockchain using winner-takes-all distribution.
+        """Set weights on the blockchain.
 
         Args:
             weights_by_hotkey: Dict of {hotkey: weight} from ScoreTracker.

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -213,10 +213,16 @@ DEMO_PID=""
 # Clean up any previous log
 rm -f "$DEMO_LOG"
 
+# Resolve venv Python
+PYTHON="python3"
+if [[ -f "$VANET_DIR/.venv/bin/python3" ]]; then
+    PYTHON="$VANET_DIR/.venv/bin/python3"
+fi
+
 # Run the miner in the background, capturing output
 (
     cd "$VANET_DIR"
-    python3 -m neurons.miner 2>&1
+    $PYTHON -m neurons.miner 2>&1
 ) > "$DEMO_LOG" 2>&1 &
 DEMO_PID=$!
 

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -12,7 +12,7 @@
 #   5. This script inspects the output VCF and prints a summary
 #
 # Usage: bash scripts/demo.sh [--template gatk|deepvariant|freebayes|bcftools]
-#        Run from the vanet/ directory.
+#        Run from the minos_subnet/ directory.
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
@@ -29,7 +29,7 @@ NC='\033[0m'
 # Resolve directories
 # ---------------------------------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-VANET_DIR="$(dirname "$SCRIPT_DIR")"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
 # ---------------------------------------------------------------------------
 # Parse arguments
@@ -126,30 +126,30 @@ echo ""
 CREATED_TEMP_ENV=false
 ORIGINAL_TEMPLATE=""
 
-if [[ -f "$VANET_DIR/.env" ]]; then
+if [[ -f "$PROJECT_DIR/.env" ]]; then
     echo -e "  ${GREEN}[OK]${NC} .env file found"
 
     # If user specified --template, temporarily override it in the env
     if [[ -n "$TEMPLATE" ]]; then
-        ORIGINAL_TEMPLATE="$(grep -E '^MINER_TEMPLATE=' "$VANET_DIR/.env" 2>/dev/null | cut -d= -f2 || true)"
+        ORIGINAL_TEMPLATE="$(grep -E '^MINER_TEMPLATE=' "$PROJECT_DIR/.env" 2>/dev/null | cut -d= -f2 || true)"
         if [[ "$ORIGINAL_TEMPLATE" != "$TEMPLATE" ]]; then
             # Use a temp copy so we don't modify the user's .env
-            cp "$VANET_DIR/.env" "$VANET_DIR/.env.demo.bak"
-            sed -i.tmp "s/^MINER_TEMPLATE=.*/MINER_TEMPLATE=$TEMPLATE/" "$VANET_DIR/.env"
-            rm -f "$VANET_DIR/.env.tmp"
+            cp "$PROJECT_DIR/.env" "$PROJECT_DIR/.env.demo.bak"
+            sed -i.tmp "s/^MINER_TEMPLATE=.*/MINER_TEMPLATE=$TEMPLATE/" "$PROJECT_DIR/.env"
+            rm -f "$PROJECT_DIR/.env.tmp"
             echo -e "  ${YELLOW}[INFO]${NC} Overriding template: ${ORIGINAL_TEMPLATE:-unset} -> $TEMPLATE"
             CREATED_TEMP_ENV=true
         fi
     fi
 
-    ACTIVE_TEMPLATE="$(grep -E '^MINER_TEMPLATE=' "$VANET_DIR/.env" 2>/dev/null | cut -d= -f2 || echo 'gatk')"
+    ACTIVE_TEMPLATE="$(grep -E '^MINER_TEMPLATE=' "$PROJECT_DIR/.env" 2>/dev/null | cut -d= -f2 || echo 'gatk')"
     echo -e "  ${GREEN}[OK]${NC} Variant caller: ${CYAN}$ACTIVE_TEMPLATE${NC}"
 else
     echo -e "  ${YELLOW}[WARN]${NC} No .env file found — creating a temporary demo config"
 
     ACTIVE_TEMPLATE="${TEMPLATE:-gatk}"
 
-    cat > "$VANET_DIR/.env" <<ENVEOF
+    cat > "$PROJECT_DIR/.env" <<ENVEOF
 # Temporary demo configuration — created by demo.sh
 # Copy .env.miner.example to .env and customize for production use.
 NETUID=107
@@ -172,12 +172,12 @@ echo ""
 # ---------------------------------------------------------------------------
 cleanup() {
     if [[ "$CREATED_TEMP_ENV" == "true" ]]; then
-        if [[ -f "$VANET_DIR/.env.demo.bak" ]]; then
+        if [[ -f "$PROJECT_DIR/.env.demo.bak" ]]; then
             # We modified an existing .env — restore it
-            mv "$VANET_DIR/.env.demo.bak" "$VANET_DIR/.env"
-        elif grep -q "created by demo.sh" "$VANET_DIR/.env" 2>/dev/null; then
+            mv "$PROJECT_DIR/.env.demo.bak" "$PROJECT_DIR/.env"
+        elif grep -q "created by demo.sh" "$PROJECT_DIR/.env" 2>/dev/null; then
             # We created a throwaway .env — remove it
-            rm -f "$VANET_DIR/.env"
+            rm -f "$PROJECT_DIR/.env"
         fi
     fi
 }
@@ -206,7 +206,7 @@ echo ""
 # once we see the "DEMO COMPLETE" or "demo mode" banner, or after
 # a timeout.
 
-DEMO_LOG="$VANET_DIR/.demo_output.log"
+DEMO_LOG="$PROJECT_DIR/.demo_output.log"
 DEMO_TIMEOUT=1800  # 30 minutes max
 DEMO_PID=""
 
@@ -215,13 +215,13 @@ rm -f "$DEMO_LOG"
 
 # Resolve venv Python
 PYTHON="python3"
-if [[ -f "$VANET_DIR/.venv/bin/python3" ]]; then
-    PYTHON="$VANET_DIR/.venv/bin/python3"
+if [[ -f "$PROJECT_DIR/.venv/bin/python3" ]]; then
+    PYTHON="$PROJECT_DIR/.venv/bin/python3"
 fi
 
 # Run the miner in the background, capturing output
 (
-    cd "$VANET_DIR"
+    cd "$PROJECT_DIR"
     $PYTHON -m neurons.miner 2>&1
 ) > "$DEMO_LOG" 2>&1 &
 DEMO_PID=$!
@@ -308,7 +308,7 @@ if [[ $SECONDS_WAITED -ge $DEMO_TIMEOUT ]]; then
     echo ""
     echo -e "  Check the full log: ${CYAN}$DEMO_LOG${NC}"
     echo -e "  Or try running the miner directly:"
-    echo -e "    cd $VANET_DIR && python3 -m neurons.miner"
+    echo -e "    cd $PROJECT_DIR && bash start-miner.sh"
     exit 1
 fi
 
@@ -322,13 +322,13 @@ echo ""
 VCF_FILE=""
 ROUND_DIR=""
 
-# The miner writes output to vanet/datasets/rounds/<round_id>/output.vcf.gz
-if [[ -d "$VANET_DIR/datasets/rounds" ]]; then
+# The miner writes output to output/<round_id>/output.vcf.gz
+if [[ -d "$PROJECT_DIR/output" ]]; then
     # Find the newest output.vcf.gz
-    VCF_FILE=$(find "$VANET_DIR/datasets/rounds" -name "output.vcf.gz" -type f -newer "$DEMO_LOG" 2>/dev/null | head -1 || true)
+    VCF_FILE=$(find "$PROJECT_DIR/output" -name "output.vcf.gz" -type f -newer "$DEMO_LOG" 2>/dev/null | head -1 || true)
     if [[ -z "$VCF_FILE" ]]; then
         # Fallback: find any output.vcf.gz, sorted by time
-        VCF_FILE=$(find "$VANET_DIR/datasets/rounds" -name "output.vcf.gz" -type f 2>/dev/null | xargs ls -t 2>/dev/null | head -1 || true)
+        VCF_FILE=$(find "$PROJECT_DIR/output" -name "output.vcf.gz" -type f 2>/dev/null | xargs ls -t 2>/dev/null | head -1 || true)
     fi
 fi
 
@@ -405,17 +405,21 @@ echo -e "${BOLD}================================================================
 echo ""
 echo -e "  When live rounds are active, validators score your VCF using"
 echo -e "  ${CYAN}hap.py${NC} (Illumina's variant comparison tool) against a truth set."
+echo -e "  The ${CYAN}AdvancedScorer${NC} combines metrics into a 0-100 final score:"
 echo ""
-echo -e "  ${BOLD}Metrics:${NC}"
-echo -e "    F1(SNP)   x 0.7  — how accurate your SNP calls are"
-echo -e "    F1(INDEL) x 0.3  — how accurate your INDEL calls are"
-echo -e "    Final = SNP_score * 0.7 + INDEL_score * 0.3"
+echo -e "  ${BOLD}Score Components:${NC}"
+echo -e "    Core F1        60%  — truth-weighted F1 across SNPs and INDELs"
+echo -e "    Completeness   15%  — recall and coverage"
+echo -e "    FP Rate        15%  — false positive penalty"
+echo -e "    Quality        10%  — Ti/Tv and Het/Hom ratio consistency"
 echo ""
-echo -e "  ${BOLD}Typical score ranges:${NC}"
-echo -e "    0.95 - 1.00  ${GREEN}Excellent${NC}  — competitive for top rewards"
-echo -e "    0.85 - 0.95  ${YELLOW}Good${NC}       — solid but room to optimize"
-echo -e "    0.70 - 0.85  ${YELLOW}Fair${NC}       — basic pipeline working"
-echo -e "    < 0.70       ${RED}Needs work${NC} — check tool parameters"
+echo -e "  The raw score (0-100) is normalized to 0-1 for EMA tracking."
+echo ""
+echo -e "  ${BOLD}Typical score ranges (0-100):${NC}"
+echo -e "    80 - 95+  ${GREEN}Excellent${NC}  — competitive for top rewards"
+echo -e "    60 - 80   ${YELLOW}Good${NC}       — solid but room to optimize"
+echo -e "    40 - 60   ${YELLOW}Fair${NC}       — check tool parameters"
+echo -e "    < 40      ${RED}Needs work${NC} — likely a configuration issue"
 echo ""
 echo -e "  ${BOLD}Tips to improve your score:${NC}"
 echo -e "    - Tune parameters in ${CYAN}configs/$ACTIVE_TEMPLATE.conf${NC}"
@@ -444,14 +448,16 @@ echo -e "     Edit ${CYAN}configs/$ACTIVE_TEMPLATE.conf${NC} to tweak tool-speci
 echo -e "     See templates/${ACTIVE_TEMPLATE}.py for supported parameters."
 echo ""
 echo -e "  ${BOLD}4. Run the miner for real:${NC}"
-echo -e "     cd $VANET_DIR"
-echo -e "     python3 -m neurons.miner"
+echo -e "     cd $PROJECT_DIR"
+echo -e "     bash start-miner.sh          # interactive (recommended first time)"
+echo -e "     bash pm2-miner.sh            # PM2 (auto-restart, background)"
 echo ""
 echo -e "     The miner will poll for rounds every 30 seconds and"
 echo -e "     automatically participate in each 72-minute round cycle."
 echo ""
 echo -e "  ${BOLD}5. Monitor your miner:${NC}"
-echo -e "     python3 -m neurons.status"
+echo -e "     pm2 logs minos-miner         # if using PM2"
+echo -e "     bash scripts/verify.sh       # check environment"
 echo -e "     Dashboard: ${CYAN}https://app.theminos.ai${NC}"
 echo ""
 echo -e "${BOLD}================================================================${NC}"

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,0 +1,460 @@
+#!/usr/bin/env bash
+# Minos Subnet 107 — Interactive Demo
+# Runs a single demo round end-to-end so a new miner can verify
+# that their variant-calling pipeline works before going live.
+#
+# What happens:
+#   1. Runs verify.sh to check prerequisites (Docker, Python, etc.)
+#   2. Ensures a .env file exists (creates a temporary demo one if not)
+#   3. Starts the miner, which connects to the platform in demo mode
+#   4. The miner downloads a BAM file, runs your chosen variant caller,
+#      and attempts to submit — the platform responds with "demo complete"
+#   5. This script inspects the output VCF and prints a summary
+#
+# Usage: bash scripts/demo.sh [--template gatk|deepvariant|freebayes|bcftools]
+#        Run from the vanet/ directory.
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Colors (same palette as verify.sh)
+# ---------------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# ---------------------------------------------------------------------------
+# Resolve directories
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VANET_DIR="$(dirname "$SCRIPT_DIR")"
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+TEMPLATE=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --template)
+            TEMPLATE="$2"
+            shift 2
+            ;;
+        --template=*)
+            TEMPLATE="${1#*=}"
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: bash scripts/demo.sh [--template gatk|deepvariant|freebayes|bcftools]"
+            echo ""
+            echo "Runs a single demo round to verify your miner setup."
+            echo "If --template is not specified, the value from .env is used (default: gatk)."
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Unknown argument: $1${NC}"
+            echo "Usage: bash scripts/demo.sh [--template gatk|deepvariant|freebayes|bcftools]"
+            exit 1
+            ;;
+    esac
+done
+
+# Validate template choice if provided
+if [[ -n "$TEMPLATE" ]]; then
+    case "$TEMPLATE" in
+        gatk|deepvariant|freebayes|bcftools) ;;
+        *)
+            echo -e "${RED}Invalid template: $TEMPLATE${NC}"
+            echo "Valid options: gatk, deepvariant, freebayes, bcftools"
+            exit 1
+            ;;
+    esac
+fi
+
+# ---------------------------------------------------------------------------
+# Banner
+# ---------------------------------------------------------------------------
+echo ""
+echo -e "${BOLD}================================================================${NC}"
+echo -e "${BOLD}  Minos SN107 — Demo Round${NC}"
+echo -e "${BOLD}================================================================${NC}"
+echo ""
+echo -e "  This script runs a ${CYAN}single demo round${NC} end-to-end so you can"
+echo -e "  confirm that your miner setup works before going live."
+echo ""
+echo -e "  What will happen:"
+echo -e "    1. Verify prerequisites (Docker, Python packages, wallet)"
+echo -e "    2. Start the miner in demo mode (no registration required)"
+echo -e "    3. The miner connects to ${CYAN}https://api.theminos.ai${NC}"
+echo -e "    4. It downloads a BAM file and runs your variant caller"
+echo -e "    5. Results are displayed here with a score estimate"
+echo ""
+echo -e "  ${YELLOW}Estimated time: 3-30 minutes${NC} (depends on your machine and"
+echo -e "  the variant caller — bcftools is fastest, DeepVariant slowest)"
+echo ""
+echo -e "  Press Ctrl+C at any time to abort."
+echo ""
+
+# ---------------------------------------------------------------------------
+# Step 1: Run verify.sh
+# ---------------------------------------------------------------------------
+echo -e "${BOLD}--- Step 1/4: Verifying prerequisites ---${NC}"
+echo ""
+
+if [[ ! -f "$SCRIPT_DIR/verify.sh" ]]; then
+    echo -e "  ${RED}[FAIL]${NC} verify.sh not found at $SCRIPT_DIR/verify.sh"
+    exit 1
+fi
+
+if ! bash "$SCRIPT_DIR/verify.sh" --miner; then
+    echo ""
+    echo -e "${RED}Prerequisites check failed. Fix the issues above and re-run.${NC}"
+    exit 1
+fi
+
+echo ""
+echo -e "  ${GREEN}Prerequisites OK.${NC}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Step 2: Ensure .env exists
+# ---------------------------------------------------------------------------
+echo -e "${BOLD}--- Step 2/4: Checking configuration ---${NC}"
+echo ""
+
+CREATED_TEMP_ENV=false
+ORIGINAL_TEMPLATE=""
+
+if [[ -f "$VANET_DIR/.env" ]]; then
+    echo -e "  ${GREEN}[OK]${NC} .env file found"
+
+    # If user specified --template, temporarily override it in the env
+    if [[ -n "$TEMPLATE" ]]; then
+        ORIGINAL_TEMPLATE="$(grep -E '^MINER_TEMPLATE=' "$VANET_DIR/.env" 2>/dev/null | cut -d= -f2 || true)"
+        if [[ "$ORIGINAL_TEMPLATE" != "$TEMPLATE" ]]; then
+            # Use a temp copy so we don't modify the user's .env
+            cp "$VANET_DIR/.env" "$VANET_DIR/.env.demo.bak"
+            sed -i.tmp "s/^MINER_TEMPLATE=.*/MINER_TEMPLATE=$TEMPLATE/" "$VANET_DIR/.env"
+            rm -f "$VANET_DIR/.env.tmp"
+            echo -e "  ${YELLOW}[INFO]${NC} Overriding template: ${ORIGINAL_TEMPLATE:-unset} -> $TEMPLATE"
+            CREATED_TEMP_ENV=true
+        fi
+    fi
+
+    ACTIVE_TEMPLATE="$(grep -E '^MINER_TEMPLATE=' "$VANET_DIR/.env" 2>/dev/null | cut -d= -f2 || echo 'gatk')"
+    echo -e "  ${GREEN}[OK]${NC} Variant caller: ${CYAN}$ACTIVE_TEMPLATE${NC}"
+else
+    echo -e "  ${YELLOW}[WARN]${NC} No .env file found — creating a temporary demo config"
+
+    ACTIVE_TEMPLATE="${TEMPLATE:-gatk}"
+
+    cat > "$VANET_DIR/.env" <<ENVEOF
+# Temporary demo configuration — created by demo.sh
+# Copy .env.miner.example to .env and customize for production use.
+NETUID=107
+WALLET_NAME=default
+WALLET_HOTKEY=default
+MINER_TEMPLATE=$ACTIVE_TEMPLATE
+PLATFORM_URL=https://api.theminos.ai
+PLATFORM_TIMEOUT=60
+STORAGE_PRIMARY_BACKEND=hippius
+ENVEOF
+
+    CREATED_TEMP_ENV=true
+    echo -e "  ${GREEN}[OK]${NC} Temporary .env created (template: ${CYAN}$ACTIVE_TEMPLATE${NC})"
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# Cleanup function — restore .env and remove temp files
+# ---------------------------------------------------------------------------
+cleanup() {
+    if [[ "$CREATED_TEMP_ENV" == "true" ]]; then
+        if [[ -f "$VANET_DIR/.env.demo.bak" ]]; then
+            # We modified an existing .env — restore it
+            mv "$VANET_DIR/.env.demo.bak" "$VANET_DIR/.env"
+        elif grep -q "created by demo.sh" "$VANET_DIR/.env" 2>/dev/null; then
+            # We created a throwaway .env — remove it
+            rm -f "$VANET_DIR/.env"
+        fi
+    fi
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Step 3: Run the miner and capture output
+# ---------------------------------------------------------------------------
+echo -e "${BOLD}--- Step 3/4: Running demo round ---${NC}"
+echo ""
+echo -e "  Starting miner with template ${CYAN}$ACTIVE_TEMPLATE${NC}..."
+echo -e "  The miner will poll the platform for the demo round, download"
+echo -e "  a BAM file, and run variant calling inside Docker."
+echo ""
+echo -e "  ${YELLOW}You will see miner logs below. This may take several minutes.${NC}"
+echo -e "  ${YELLOW}The demo ends automatically after one round completes.${NC}"
+echo ""
+echo -e "  ---- miner output begin ----"
+echo ""
+
+# We run the miner and watch for the demo-complete signal.
+# The miner runs forever in a polling loop, so we need to kill it
+# once we see it has completed the demo round.
+#
+# Strategy: run the miner in background, tail its output, and kill it
+# once we see the "DEMO COMPLETE" or "demo mode" banner, or after
+# a timeout.
+
+DEMO_LOG="$VANET_DIR/.demo_output.log"
+DEMO_TIMEOUT=1800  # 30 minutes max
+DEMO_PID=""
+
+# Clean up any previous log
+rm -f "$DEMO_LOG"
+
+# Run the miner in the background, capturing output
+(
+    cd "$VANET_DIR"
+    python3 -m neurons.miner 2>&1
+) > "$DEMO_LOG" 2>&1 &
+DEMO_PID=$!
+
+# Also clean up child process on exit
+cleanup_all() {
+    if [[ -n "$DEMO_PID" ]] && kill -0 "$DEMO_PID" 2>/dev/null; then
+        kill "$DEMO_PID" 2>/dev/null || true
+        wait "$DEMO_PID" 2>/dev/null || true
+    fi
+    rm -f "$DEMO_LOG"
+    cleanup
+}
+trap cleanup_all EXIT
+
+# Follow the log in real time, watching for completion signals
+SECONDS_WAITED=0
+DEMO_COMPLETE=false
+LAST_LINE=0
+
+while [[ $SECONDS_WAITED -lt $DEMO_TIMEOUT ]]; do
+    # Check if miner process is still running
+    if ! kill -0 "$DEMO_PID" 2>/dev/null; then
+        # Process ended — print remaining output
+        if [[ -f "$DEMO_LOG" ]]; then
+            tail -n +$((LAST_LINE + 1)) "$DEMO_LOG" 2>/dev/null || true
+        fi
+        break
+    fi
+
+    # Print new lines from the log
+    if [[ -f "$DEMO_LOG" ]]; then
+        NEW_LINES=$(wc -l < "$DEMO_LOG" 2>/dev/null || echo 0)
+        if [[ "$NEW_LINES" -gt "$LAST_LINE" ]]; then
+            tail -n +$((LAST_LINE + 1)) "$DEMO_LOG" | head -n $((NEW_LINES - LAST_LINE))
+            LAST_LINE=$NEW_LINES
+        fi
+
+        # Check for demo completion signals
+        if grep -q "DEMO COMPLETE" "$DEMO_LOG" 2>/dev/null; then
+            DEMO_COMPLETE=true
+            sleep 2  # Let the miner finish printing
+            # Print any final lines
+            NEW_LINES=$(wc -l < "$DEMO_LOG" 2>/dev/null || echo 0)
+            if [[ "$NEW_LINES" -gt "$LAST_LINE" ]]; then
+                tail -n +$((LAST_LINE + 1)) "$DEMO_LOG" | head -n $((NEW_LINES - LAST_LINE))
+            fi
+            break
+        fi
+
+        # Also check for errors that indicate the round was processed
+        if grep -q "Total rounds participated: 1" "$DEMO_LOG" 2>/dev/null; then
+            DEMO_COMPLETE=true
+            sleep 2
+            NEW_LINES=$(wc -l < "$DEMO_LOG" 2>/dev/null || echo 0)
+            if [[ "$NEW_LINES" -gt "$LAST_LINE" ]]; then
+                tail -n +$((LAST_LINE + 1)) "$DEMO_LOG" | head -n $((NEW_LINES - LAST_LINE))
+            fi
+            break
+        fi
+    fi
+
+    sleep 2
+    SECONDS_WAITED=$((SECONDS_WAITED + 2))
+done
+
+echo ""
+echo -e "  ---- miner output end ----"
+echo ""
+
+# Kill the miner if it is still running
+if [[ -n "$DEMO_PID" ]] && kill -0 "$DEMO_PID" 2>/dev/null; then
+    kill "$DEMO_PID" 2>/dev/null || true
+    wait "$DEMO_PID" 2>/dev/null || true
+fi
+
+# Check what happened
+if [[ $SECONDS_WAITED -ge $DEMO_TIMEOUT ]]; then
+    echo -e "  ${RED}[TIMEOUT]${NC} Demo did not complete within $((DEMO_TIMEOUT / 60)) minutes."
+    echo -e "  This might mean:"
+    echo -e "    - No demo round is currently active on the platform"
+    echo -e "    - Docker is slow to start on your machine"
+    echo -e "    - The variant caller hit an error"
+    echo ""
+    echo -e "  Check the full log: ${CYAN}$DEMO_LOG${NC}"
+    echo -e "  Or try running the miner directly:"
+    echo -e "    cd $VANET_DIR && python3 -m neurons.miner"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4: Inspect results
+# ---------------------------------------------------------------------------
+echo -e "${BOLD}--- Step 4/4: Results summary ---${NC}"
+echo ""
+
+# Find the most recent output VCF in the working directory
+VCF_FILE=""
+ROUND_DIR=""
+
+# The miner writes output to vanet/datasets/rounds/<round_id>/output.vcf.gz
+if [[ -d "$VANET_DIR/datasets/rounds" ]]; then
+    # Find the newest output.vcf.gz
+    VCF_FILE=$(find "$VANET_DIR/datasets/rounds" -name "output.vcf.gz" -type f -newer "$DEMO_LOG" 2>/dev/null | head -1 || true)
+    if [[ -z "$VCF_FILE" ]]; then
+        # Fallback: find any output.vcf.gz, sorted by time
+        VCF_FILE=$(find "$VANET_DIR/datasets/rounds" -name "output.vcf.gz" -type f 2>/dev/null | xargs ls -t 2>/dev/null | head -1 || true)
+    fi
+fi
+
+if [[ -n "$VCF_FILE" && -f "$VCF_FILE" ]]; then
+    ROUND_DIR="$(dirname "$VCF_FILE")"
+    VCF_SIZE=$(du -h "$VCF_FILE" | cut -f1)
+
+    echo -e "  ${GREEN}[OK]${NC} Output VCF found: $VCF_FILE ($VCF_SIZE)"
+    echo ""
+
+    # Count variants
+    VARIANT_COUNT=0
+    SNP_COUNT=0
+    INDEL_COUNT=0
+
+    if command -v zcat &>/dev/null || command -v gzcat &>/dev/null; then
+        # macOS uses gzcat, Linux uses zcat
+        ZCAT="zcat"
+        if [[ "$(uname)" == "Darwin" ]]; then
+            ZCAT="gzcat"
+        fi
+
+        VARIANT_COUNT=$($ZCAT "$VCF_FILE" 2>/dev/null | grep -v "^#" | wc -l | tr -d ' ' || echo 0)
+
+        # Count SNPs vs INDELs (SNP = REF and ALT are both single chars)
+        SNP_COUNT=$($ZCAT "$VCF_FILE" 2>/dev/null | grep -v "^#" | awk 'length($4)==1 && length($5)==1' | wc -l | tr -d ' ' || echo 0)
+        INDEL_COUNT=$((VARIANT_COUNT - SNP_COUNT))
+
+        echo -e "  ${BOLD}Variant Summary:${NC}"
+        echo -e "    Total variants: ${CYAN}$VARIANT_COUNT${NC}"
+        echo -e "    SNPs:           ${CYAN}$SNP_COUNT${NC}"
+        echo -e "    INDELs:         ${CYAN}$INDEL_COUNT${NC}"
+        echo ""
+
+        # Show first 10 data lines
+        echo -e "  ${BOLD}First 10 variant calls:${NC}"
+        echo ""
+        $ZCAT "$VCF_FILE" 2>/dev/null | grep -v "^#" | head -10 | while IFS=$'\t' read -r CHROM POS ID REF ALT QUAL FILTER REST; do
+            # Determine variant type
+            if [[ ${#REF} -eq 1 && ${#ALT} -eq 1 ]]; then
+                VTYPE="SNP"
+            else
+                VTYPE="INDEL"
+            fi
+            printf "    %-6s %-12s %s>%s  QUAL=%-8s %s\n" "$CHROM" "$POS" "$REF" "$ALT" "$QUAL" "$VTYPE"
+        done
+        echo ""
+
+        if [[ $VARIANT_COUNT -gt 10 ]]; then
+            echo -e "    ... and $((VARIANT_COUNT - 10)) more variants"
+            echo ""
+        fi
+    else
+        echo -e "  ${YELLOW}[WARN]${NC} Cannot decompress VCF (zcat/gzcat not found)"
+        echo -e "  File exists at: $VCF_FILE"
+    fi
+else
+    if [[ "$DEMO_COMPLETE" == "true" ]]; then
+        echo -e "  ${YELLOW}[INFO]${NC} Demo round completed but no VCF file found."
+        echo -e "  The demo round may have been a connectivity-only test."
+    else
+        echo -e "  ${RED}[FAIL]${NC} No output VCF found. The variant caller may have failed."
+        echo -e "  Check the miner logs above for error messages."
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Scoring explanation
+# ---------------------------------------------------------------------------
+echo ""
+echo -e "${BOLD}================================================================${NC}"
+echo -e "${BOLD}  How Scoring Works on Minos SN107${NC}"
+echo -e "${BOLD}================================================================${NC}"
+echo ""
+echo -e "  When live rounds are active, validators score your VCF using"
+echo -e "  ${CYAN}hap.py${NC} (Illumina's variant comparison tool) against a truth set."
+echo ""
+echo -e "  ${BOLD}Metrics:${NC}"
+echo -e "    F1(SNP)   x 0.7  — how accurate your SNP calls are"
+echo -e "    F1(INDEL) x 0.3  — how accurate your INDEL calls are"
+echo -e "    Final = SNP_score * 0.7 + INDEL_score * 0.3"
+echo ""
+echo -e "  ${BOLD}Typical score ranges:${NC}"
+echo -e "    0.95 - 1.00  ${GREEN}Excellent${NC}  — competitive for top rewards"
+echo -e "    0.85 - 0.95  ${YELLOW}Good${NC}       — solid but room to optimize"
+echo -e "    0.70 - 0.85  ${YELLOW}Fair${NC}       — basic pipeline working"
+echo -e "    < 0.70       ${RED}Needs work${NC} — check tool parameters"
+echo ""
+echo -e "  ${BOLD}Tips to improve your score:${NC}"
+echo -e "    - Tune parameters in ${CYAN}configs/$ACTIVE_TEMPLATE.conf${NC}"
+echo -e "    - Try different variant callers (GATK and DeepVariant score highest)"
+echo -e "    - Ensure enough RAM is available for your tool"
+echo -e "      (DeepVariant: 8GB+, GATK: 4GB+, bcftools/freebayes: 2GB+)"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Next steps
+# ---------------------------------------------------------------------------
+echo -e "${BOLD}================================================================${NC}"
+echo -e "${BOLD}  Next Steps${NC}"
+echo -e "${BOLD}================================================================${NC}"
+echo ""
+echo -e "  ${BOLD}1. Register on the subnet:${NC}"
+echo -e "     btcli subnets register --netuid 107 \\"
+echo -e "       --wallet.name <your_wallet> --wallet.hotkey <your_hotkey>"
+echo ""
+echo -e "  ${BOLD}2. Configure your .env:${NC}"
+echo -e "     cp .env.miner.example .env"
+echo -e "     # Edit .env with your wallet name, hotkey, and preferred template"
+echo ""
+echo -e "  ${BOLD}3. (Optional) Tune variant-caller parameters:${NC}"
+echo -e "     Edit ${CYAN}configs/$ACTIVE_TEMPLATE.conf${NC} to tweak tool-specific settings."
+echo -e "     See templates/${ACTIVE_TEMPLATE}.py for supported parameters."
+echo ""
+echo -e "  ${BOLD}4. Run the miner for real:${NC}"
+echo -e "     cd $VANET_DIR"
+echo -e "     python3 -m neurons.miner"
+echo ""
+echo -e "     The miner will poll for rounds every 30 seconds and"
+echo -e "     automatically participate in each 72-minute round cycle."
+echo ""
+echo -e "  ${BOLD}5. Monitor your miner:${NC}"
+echo -e "     python3 -m neurons.status"
+echo -e "     Dashboard: ${CYAN}https://app.theminos.ai${NC}"
+echo ""
+echo -e "${BOLD}================================================================${NC}"
+
+if [[ "$DEMO_COMPLETE" == "true" ]]; then
+    echo -e "  ${GREEN}Demo completed successfully. Your miner is ready!${NC}"
+else
+    echo -e "  ${YELLOW}Demo finished (check output above for any issues).${NC}"
+fi
+
+echo -e "${BOLD}================================================================${NC}"
+echo ""

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -13,6 +13,16 @@ fail() { echo -e "  ${RED}[FAIL]${NC} $1"; FAIL=$((FAIL+1)); }
 
 ROLE="${1:---miner}"
 
+# Resolve project root and activate venv if available
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+PYTHON="python3"
+if [[ -f "$PROJECT_DIR/.venv/bin/python3" ]]; then
+    PYTHON="$PROJECT_DIR/.venv/bin/python3"
+elif [[ -f "$PROJECT_DIR/.venv/bin/python" ]]; then
+    PYTHON="$PROJECT_DIR/.venv/bin/python"
+fi
+
 echo "=================================="
 echo "  Minos SN107 — Setup Verification"
 echo "  Role: ${ROLE#--}"
@@ -21,15 +31,15 @@ echo ""
 
 # --- Python ---
 echo "Python:"
-if command -v python3 &>/dev/null; then
-    pass "python3 $(python3 --version 2>&1 | awk '{print $2}')"
+if [[ -x "$PYTHON" ]] || command -v "$PYTHON" &>/dev/null; then
+    pass "$PYTHON ($($PYTHON --version 2>&1 | awk '{print $2}'))"
 else
     fail "python3 not found"
 fi
 
 for pkg in bittensor pysam boto3 dotenv; do
-    if python3 -c "import ${pkg}" 2>/dev/null; then
-        pass "python3 -c 'import ${pkg}'"
+    if $PYTHON -c "import ${pkg}" 2>/dev/null; then
+        pass "$PYTHON -c 'import ${pkg}'"
     else
         pip_name="${pkg}"
         [[ "$pkg" == "dotenv" ]] && pip_name="python-dotenv"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -113,11 +113,11 @@ fi
 echo ""
 echo "Configuration:"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-VANET_DIR="$(dirname "$SCRIPT_DIR")"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
-if [ -f "$VANET_DIR/.env" ]; then
+if [ -f "$PROJECT_DIR/.env" ]; then
     pass ".env found"
-elif [ -f "$VANET_DIR/.env.miner.example" ]; then
+elif [ -f "$PROJECT_DIR/.env.miner.example" ]; then
     warn "No .env — copy from .env.${ROLE#--}.example and fill in values"
 else
     warn "No .env file found"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Minos Subnet 107 — Environment Verification
+# Checks that all prerequisites are installed and configured.
+# Usage: bash scripts/verify.sh [--miner|--validator]
+set -euo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'; NC='\033[0m'
+PASS=0; WARN=0; FAIL=0
+
+pass() { echo -e "  ${GREEN}[OK]${NC} $1"; PASS=$((PASS+1)); }
+warn() { echo -e "  ${YELLOW}[WARN]${NC} $1"; WARN=$((WARN+1)); }
+fail() { echo -e "  ${RED}[FAIL]${NC} $1"; FAIL=$((FAIL+1)); }
+
+ROLE="${1:---miner}"
+
+echo "=================================="
+echo "  Minos SN107 — Setup Verification"
+echo "  Role: ${ROLE#--}"
+echo "=================================="
+echo ""
+
+# --- Python ---
+echo "Python:"
+if command -v python3 &>/dev/null; then
+    pass "python3 $(python3 --version 2>&1 | awk '{print $2}')"
+else
+    fail "python3 not found"
+fi
+
+for pkg in bittensor pysam boto3 dotenv; do
+    if python3 -c "import ${pkg}" 2>/dev/null; then
+        pass "python3 -c 'import ${pkg}'"
+    else
+        pip_name="${pkg}"
+        [[ "$pkg" == "dotenv" ]] && pip_name="python-dotenv"
+        fail "Missing Python package: ${pkg} (pip install ${pip_name})"
+    fi
+done
+
+# --- Docker (required) ---
+echo ""
+echo "Docker:"
+if command -v docker &>/dev/null; then
+    pass "docker installed ($(docker --version 2>&1 | head -1))"
+else
+    fail "Docker not installed — required for variant calling"
+    echo "       Install: https://docs.docker.com/get-docker/"
+fi
+
+if docker info &>/dev/null; then
+    pass "Docker daemon running"
+else
+    fail "Docker daemon not running — start Docker and try again"
+fi
+
+# --- Docker images ---
+echo ""
+echo "Docker images:"
+
+MINER_IMAGES=(
+    "broadinstitute/gatk:4.5.0.0"
+    "google/deepvariant:1.5.0"
+    "staphb/freebayes:1.3.7"
+    "quay.io/biocontainers/bcftools:1.20--h8b25389_0"
+    "quay.io/biocontainers/samtools:1.20--h50ea8bc_0"
+)
+VALIDATOR_IMAGES=(
+    "genonet/hap-py@sha256:03acabe84bbfba35f5a7234129d524c563f5657e1f21150a2ea2797f8e6d05f2"
+)
+
+check_images() {
+    for img in "$@"; do
+        if docker image inspect "$img" &>/dev/null; then
+            short="${img##*/}"
+            pass "$short"
+        else
+            short="${img##*/}"
+            warn "$short not pulled (docker pull $img)"
+        fi
+    done
+}
+
+if [[ "$ROLE" == "--miner" ]]; then
+    check_images "${MINER_IMAGES[@]}"
+    echo -e "  ${YELLOW}Note:${NC} You only need the image for your chosen variant caller."
+elif [[ "$ROLE" == "--validator" ]]; then
+    check_images "${VALIDATOR_IMAGES[@]}"
+    check_images "${MINER_IMAGES[@]}"
+fi
+
+# --- Wallet ---
+echo ""
+echo "Bittensor wallet:"
+WALLET_PATH="$HOME/.bittensor/wallets"
+if [ -d "$WALLET_PATH" ] && [ "$(ls -A "$WALLET_PATH" 2>/dev/null)" ]; then
+    wallets=$(ls "$WALLET_PATH" 2>/dev/null | head -5)
+    pass "Wallet(s) found: $wallets"
+else
+    warn "No wallets in $WALLET_PATH — create with: btcli wallet create"
+fi
+
+# --- .env ---
+echo ""
+echo "Configuration:"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VANET_DIR="$(dirname "$SCRIPT_DIR")"
+
+if [ -f "$VANET_DIR/.env" ]; then
+    pass ".env found"
+elif [ -f "$VANET_DIR/.env.miner.example" ]; then
+    warn "No .env — copy from .env.${ROLE#--}.example and fill in values"
+else
+    warn "No .env file found"
+fi
+
+# --- Summary ---
+echo ""
+echo "=================================="
+echo -e "  ${GREEN}Passed: $PASS${NC}  ${YELLOW}Warnings: $WARN${NC}  ${RED}Failed: $FAIL${NC}"
+echo "=================================="
+
+if [ $FAIL -gt 0 ]; then
+    echo -e "${RED}Fix the failures above before running your ${ROLE#--}.${NC}"
+    exit 1
+elif [ $WARN -gt 0 ]; then
+    echo -e "${YELLOW}Warnings are non-blocking but should be addressed.${NC}"
+    exit 0
+else
+    echo -e "${GREEN}All checks passed — ready to run!${NC}"
+    exit 0
+fi

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ MINER_DOCKER_IMAGES = {
 }
 
 VALIDATOR_DOCKER_IMAGES = [
-    "genonet/hap-py:0.3.15",
+    "genonet/hap-py@sha256:03acabe84bbfba35f5a7234129d524c563f5657e1f21150a2ea2797f8e6d05f2",
     "broadinstitute/gatk:4.5.0.0",
     "google/deepvariant:1.5.0",
     "staphb/freebayes:1.3.7",
@@ -893,16 +893,16 @@ class SetupWizard:
             "How would you like to run your node?",
             choices=[
                 questionary.Choice(
-                    f"Run directly  (python -m neurons.{role})",
-                    value="direct",
+                    "Generate PM2 config  (recommended — auto-restart, logs, monitoring)",
+                    value="pm2",
                 ),
                 questionary.Choice(
                     "Generate systemd service  (Linux, auto-restart)",
                     value="systemd",
                 ),
                 questionary.Choice(
-                    "Generate PM2 config  (Node.js process manager)",
-                    value="pm2",
+                    f"Run directly  (python -m neurons.{role})",
+                    value="direct",
                 ),
                 questionary.Choice(
                     "Skip  (I will configure this myself)",
@@ -1013,38 +1013,72 @@ class SetupWizard:
             self.console.print(f"  [dim]  pm2 logs {service_name}                 # view logs[/]")
             self.console.print(f"  [dim]  pm2 save                                # persist across reboots[/]")
 
-        # Launch
-        run_cmd = f"python -m neurons.{role}"
-        self.console.print()
-        self.console.print(f"  Launch command: [bold cyan]{run_cmd}[/]")
-        self.console.print()
-
-        launch = questionary.confirm(
-            "Launch now?",
-            default=False, style=CUSTOM_STYLE,
-        ).ask()
-
-        if launch:
-            self.console.print(f"\n  [bold cyan]Starting Minos {role}...[/]\n")
+        # PM2: always register the process so pm2 status / pm2 start works
+        if pm == "pm2":
+            run_cmd = f"bash pm2-{role}.sh"
+            service_name = f"minos-{role}"
+            eco_file = str(BASE_DIR / f"ecosystem.{role}.config.js")
             os.chdir(BASE_DIR)
-            # If docker group isn't active yet (fresh install), launch via sg docker
-            needs_sg = (
-                shutil.which("sg")
-                and "docker" not in os.getgroups().__str__()
-                and subprocess.run(["docker", "info"], capture_output=True).returncode != 0
-            )
-            if needs_sg:
-                cmd_str = f"{sys.executable} -m neurons.{role}"
-                sys.exit(subprocess.call(["sg", "docker", "-c", cmd_str]))
-            else:
-                sys.exit(subprocess.call([sys.executable, "-m", f"neurons.{role}"]))
 
-        self.console.print(f"\n  To start later:")
-        self.console.print(f"  [dim]  cd {BASE_DIR}[/]")
-        self.console.print(f"  [dim]  source .venv/bin/activate[/]")
-        self.console.print(f"  [dim]  {run_cmd}[/]")
-        self.console.print()
-        self.console.print(f"  [dim]  If Docker gives a permission error, run: newgrp docker[/]")
+            # Register with PM2 (start then immediately stop if user doesn't want to launch)
+            self.console.print(f"\n  [dim]Registering {service_name} with PM2...[/]")
+            subprocess.call(["pm2", "start", eco_file], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.call(["pm2", "save"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+            launch = questionary.confirm(
+                "Launch now?",
+                default=True, style=CUSTOM_STYLE,
+            ).ask()
+
+            if launch:
+                self.console.print(f"\n  [bold cyan]Starting Minos {role} via PM2...[/]\n")
+                subprocess.call(["pm2", "restart", service_name, "--update-env"])
+                self.console.print()
+                self.console.print(f"  [green]{service_name} is running.[/]")
+                self.console.print(f"  [dim]  pm2 logs {service_name}   # view logs[/]")
+                self.console.print(f"  [dim]  pm2 status               # check status[/]")
+            else:
+                subprocess.call(["pm2", "stop", service_name], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                subprocess.call(["pm2", "save"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                self.console.print(f"\n  [green]{service_name} registered with PM2 (stopped).[/]")
+                self.console.print(f"  [dim]  pm2 start {service_name}   # start when ready[/]")
+                self.console.print(f"  [dim]  pm2 status                # check status[/]")
+        else:
+            run_cmd = f"python -m neurons.{role}"
+            self.console.print()
+            self.console.print(f"  Launch command: [bold cyan]{run_cmd}[/]")
+            self.console.print()
+
+            launch = questionary.confirm(
+                "Launch now?",
+                default=False, style=CUSTOM_STYLE,
+            ).ask()
+
+            if launch:
+                self.console.print(f"\n  [bold cyan]Starting Minos {role}...[/]\n")
+                os.chdir(BASE_DIR)
+                if pm == "systemd":
+                    service_name = f"minos-{role}"
+                    sys.exit(subprocess.call(["sudo", "systemctl", "start", service_name]))
+                else:
+                    # Direct launch
+                    needs_sg = (
+                        shutil.which("sg")
+                        and "docker" not in os.getgroups().__str__()
+                        and subprocess.run(["docker", "info"], capture_output=True).returncode != 0
+                    )
+                    if needs_sg:
+                        cmd_str = f"{sys.executable} -m neurons.{role}"
+                        sys.exit(subprocess.call(["sg", "docker", "-c", cmd_str]))
+                    else:
+                        sys.exit(subprocess.call([sys.executable, "-m", f"neurons.{role}"]))
+
+            self.console.print(f"\n  To start later:")
+            self.console.print(f"  [dim]  cd {BASE_DIR}[/]")
+            self.console.print(f"  [dim]  source .venv/bin/activate[/]")
+            self.console.print(f"  [dim]  {run_cmd}[/]")
+            self.console.print()
+            self.console.print(f"  [dim]  If Docker gives a permission error, run: newgrp docker[/]")
 
         return StepResult()
 
@@ -1361,7 +1395,9 @@ WantedBy=multi-user.target
     autorestart: true,
     max_restarts: 10,
     restart_delay: 30000,
+    kill_timeout: 15000,
     log_date_format: "YYYY-MM-DD HH:mm:ss Z",
+    env: {{ PYTHONUNBUFFERED: "1" }},
   }}]
 }};
 """

--- a/utils/README.md
+++ b/utils/README.md
@@ -4,7 +4,7 @@ This folder contains all the genomics processing tools used by miners and valida
 
 ## Overview
 
-The utils folder is organized into 6 focused modules:
+The utils folder is organized into 7 focused modules:
 
 ```text
 utils/
@@ -12,6 +12,7 @@ utils/
 ├── weight_tracking.py    # Tracks miner performance over time
 ├── file_utils.py         # Downloads and manages data files
 ├── platform_client.py    # Platform API client for miners/validators
+├── subset_scoring.py     # Subset scoring helpers (assignments, deadlines)
 ├── config_loader.py      # Config file loading for miner templates
 └── path_utils.py         # Safe filesystem paths for round directories
 ```

--- a/utils/platform_client.py
+++ b/utils/platform_client.py
@@ -553,6 +553,110 @@ class ValidatorPlatformClient(PlatformClient):
 
         return await retry_async(_do_request, max_retries=2)
 
+    async def get_assignment(
+        self,
+        round_id: str,
+    ) -> Dict[str, Any]:
+        """Get this validator's scoring assignment for a round (validator only).
+
+        The platform computes assignments from its own metagraph snapshot —
+        no metagraph data needs to be supplied by the validator.
+
+        Returns:
+            Dict containing:
+                - round_id: str
+                - validator_hotkey: str
+                - stake_rank: int
+                - total_validators: int
+                - primary_miner_hotkeys: List[str]   # score these first
+                - overlap_miner_hotkeys: List[str]   # shared with adjacent validator
+                - secondary_miner_hotkeys: List[str] # score if time allows
+                - scoring_deadline: str              # ISO datetime
+        """
+        path = "/v2/get-assignment"
+
+        async def _do_request():
+            body = self._auth_body(
+                "POST", path,
+                validator_hotkey=self.keypair.ss58_address,
+                round_id=round_id,
+            )
+
+            async with self._get_client() as client:
+                response = await client.post(path, json=body, headers=self._AUTH_HEADERS)
+
+                if response.status_code == 401:
+                    raise AuthenticationError("Invalid signature or validator not authorized")
+                if response.status_code == 404:
+                    raise PlatformClientError(f"Round or assignment not found: {response.text}")
+                if response.status_code == 409:
+                    raise PlatformClientError(f"Round not in scoring phase: {response.text}")
+                if response.status_code == 503:
+                    raise PlatformClientError(f"Assignment unavailable: {response.text}")
+                if response.status_code != 200:
+                    raise PlatformClientError(f"Failed to get assignment: {response.text}")
+
+                return response.json()
+
+        return await retry_async(_do_request, max_retries=3)
+
+    async def get_backfill_scores(
+        self,
+        round_id: str,
+        scored_miner_hotkeys: List[str],
+    ) -> Dict[str, Any]:
+        """Fetch scores for miners not personally covered this round (validator only).
+
+        Must be called after the scoring window has closed. The platform enforces
+        this gate (returns 425 Too Early if the window is still open).
+
+        Args:
+            round_id: The round to fetch backfill scores for.
+            scored_miner_hotkeys: Hotkeys this validator personally scored.
+
+        Returns:
+            Dict containing:
+                - backfill_scores: List of {miner_hotkey, combined_final,
+                                            primary_validator_hotkey, submitted_at}
+                - overlap_deltas: List of {miner_hotkey, your_score, peer_score,
+                                           delta, peer_validator_hotkey}
+                - unscored_miner_hotkeys: List[str]   # no score from any validator
+                - gap_count: int
+        """
+        path = "/v2/get-backfill-scores"
+
+        async def _do_request():
+            body = self._auth_body(
+                "POST", path,
+                validator_hotkey=self.keypair.ss58_address,
+                round_id=round_id,
+                scored_miner_hotkeys=scored_miner_hotkeys,
+            )
+
+            async with self._get_client() as client:
+                response = await client.post(
+                    path, json=body, headers=self._AUTH_HEADERS, timeout=60.0
+                )
+
+                if response.status_code == 401:
+                    raise AuthenticationError("Invalid signature or validator not authorized")
+                if response.status_code == 404:
+                    raise PlatformClientError("Round not found")
+                if response.status_code == 425:
+                    raise PlatformClientError(
+                        f"Scoring window still open (Too Early): {response.text}"
+                    )
+                if response.status_code == 503:
+                    raise PlatformClientError(
+                        f"Backfill unavailable: {response.text}"
+                    )
+                if response.status_code != 200:
+                    raise PlatformClientError(f"Failed to get backfill scores: {response.text}")
+
+                return response.json()
+
+        return await retry_async(_do_request, max_retries=2)
+
     async def submit_weight_history(
         self,
         round_id: str,

--- a/utils/subset_scoring.py
+++ b/utils/subset_scoring.py
@@ -1,0 +1,92 @@
+"""
+Helpers for subset-based validator scoring.
+
+Provides utilities for extracting miner/validator lists from the Bittensor
+metagraph and checking whether the scoring deadline is approaching.
+"""
+
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+
+def get_miners_from_metagraph(metagraph, my_uid: Optional[int] = None) -> List[str]:
+    """
+    Return hotkeys of all miners (neurons without validator_permit) in the metagraph.
+
+    Args:
+        metagraph: Bittensor metagraph object.
+        my_uid: This validator's UID — excluded from the miner list.
+
+    Returns:
+        List of miner hotkeys ordered by UID (stable ordering).
+    """
+    miners = []
+    for uid in range(len(metagraph.hotkeys)):
+        if uid == my_uid:
+            continue
+        has_permit = (
+            bool(metagraph.validator_permit[uid])
+            if hasattr(metagraph, "validator_permit")
+            else False
+        )
+        if not has_permit:
+            miners.append(metagraph.hotkeys[uid])
+    return miners
+
+
+def get_validators_from_metagraph(metagraph, my_uid: Optional[int] = None) -> List[Dict]:
+    """
+    Return a list of validator info dicts sorted by stake descending.
+
+    Args:
+        metagraph: Bittensor metagraph object.
+        my_uid: This validator's UID — included in the list (it is a validator too).
+
+    Returns:
+        List of {hotkey, stake, uid} dicts, sorted by stake descending.
+    """
+    validators = []
+    for uid in range(len(metagraph.hotkeys)):
+        has_permit = (
+            bool(metagraph.validator_permit[uid])
+            if hasattr(metagraph, "validator_permit")
+            else False
+        )
+        if has_permit:
+            stake = float(metagraph.S[uid]) if hasattr(metagraph, "S") else 0.0
+            validators.append({
+                "hotkey": metagraph.hotkeys[uid],
+                "stake": stake,
+                "uid": uid,
+            })
+    return sorted(validators, key=lambda v: (-v["stake"], v["hotkey"]))
+
+
+def seconds_until_deadline(
+    scoring_end_time: datetime,
+    tz: timezone = timezone.utc,
+) -> float:
+    """Return seconds remaining until scoring_end_time. Negative if past deadline."""
+    now = datetime.now(scoring_end_time.tzinfo or tz)
+    return (scoring_end_time - now).total_seconds()
+
+
+def should_stop_secondary_scoring(
+    scoring_end_time: Optional[datetime],
+    buffer_seconds: int = 180,
+) -> bool:
+    """
+    Return True if the scoring deadline is close enough that secondary (non-primary)
+    miners should no longer be scored.
+
+    Args:
+        scoring_end_time: Deadline from the platform assignment response.
+        buffer_seconds: Stop secondary scoring this many seconds before deadline.
+
+    Returns:
+        True if secondary scoring should stop, False to continue.
+    """
+    if scoring_end_time is None:
+        return False
+    remaining = seconds_until_deadline(scoring_end_time)
+    return remaining < buffer_seconds

--- a/utils/weight_tracking.py
+++ b/utils/weight_tracking.py
@@ -1,13 +1,13 @@
 """
-Winner-takes-all weight tracking with EMA, participation gating, and score decay.
+EMA-based weight distribution with participation gating and score decay.
 
 Tracks miner performance over time with exponential moving averages.
-The top eligible miner receives 100% of the weight; all others get 0.
+Weight distribution has two phases:
 
-Two phases:
-- Warmup (before any miner reaches min_rounds): reward split 50/30/20 among
-  top 3 scoring active miners (>= 1 round) by EMA score.
-- Normal: winner-takes-all by EMA among eligible miners.
+- Warmup (before any miner reaches min_rounds): positional reward split
+  50/30/20 among the top 3 scoring active miners (>= 1 round) by EMA.
+- Normal (once any miner is eligible): winner-takes-all — the single
+  top-performing eligible miner receives 100% of the weight.
 
 Eligibility requires scoring in at least `min_rounds` of the recent window.
 Tiebreaker: earliest submission timestamp in the most recent round.
@@ -43,7 +43,7 @@ SCORE_EPSILON = 0.005
 
 
 class ScoreTracker:
-    """Track scores with EMA and winner-takes-all weight distribution.
+    """Track scores with EMA and phase-aware weight distribution.
 
     Miners are identified by hotkey (ss58 address) for stability across
     metagraph resyncs. UID mapping happens at weight-setting time.
@@ -214,13 +214,13 @@ class ScoreTracker:
         submission_times: Optional[Dict[str, float]] = None,
     ) -> Dict[str, float]:
         """
-        Compute winner-takes-all weights.
+        Compute weight distribution.
 
         Two modes:
-        - **Warmup** (no miner has min_rounds yet): winner-takes-all by
-          EMA score, among active miners only.
+        - **Warmup** (no miner has min_rounds yet): positional split
+          (50/30/20) among top active miners by EMA score.
           Inactive miners (0 rounds) get zero weight.
-        - **Normal**: winner-takes-all by EMA among eligible miners.
+        - **Normal**: winner-takes-all — single top eligible miner gets 100%.
 
         Tiebreak in both modes: earliest submission timestamp.
 


### PR DESCRIPTION
## Summary
- Subset-based validator scoring for scalability (primary/secondary assignments, backfill)
- Docker enforcement at startup with actionable error messages
- Clearer demo mode messaging (DEMO COMPLETE block)
- PM2 auto-register on setup, launch flow improvements
- Developer onboarding: verify.sh, demo.sh, tuning guide
- hap.py image pinned to SHA256 digest across all references
- Docs aligned with runtime behavior (EMA scale, endpoints, weight distribution)

## New Files
- `scripts/verify.sh` — pre-flight environment check
- `scripts/demo.sh` — end-to-end demo runner
- `docs/tuning_guide.md` — miner tuning reference
- `utils/subset_scoring.py` — subset scoring helpers

## Changed Files
- `neurons/validator.py` — subset scoring + mode-aware weight logs
- `neurons/miner.py` — Docker enforcement + demo UX
- `setup.py` — PM2 as default, auto-register, launch flow
- `utils/platform_client.py` — assignment + backfill endpoints
- `utils/weight_tracking.py` — docstring accuracy
- Docs: README, architecture, neurons/README, utils/README, hap_py_docker