### PR TITLE
Add scoring overcall guardrail

### DIFF
--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -111,6 +111,16 @@ class TestComputeAdvancedScore:
         # Should be a good but not perfect score
         assert score > 50.0
 
+    def test_overcall_penalty_subtracted(self, sample_happy_metrics):
+        """Overcall guardrail penalty should be subtracted from final score."""
+        base_score = AdvancedScorer.compute_advanced_score(sample_happy_metrics)
+        metrics = dict(sample_happy_metrics)
+        metrics["overcall_penalty"] = 12.5
+
+        penalized_score = AdvancedScorer.compute_advanced_score(metrics)
+
+        assert penalized_score == pytest.approx(max(0.0, base_score - 12.5))
+
     def test_snp_only_truth_weighting(self):
         """When truth_total_indel=0, weighting should only use SNP F1."""
         metrics = {

--- a/tests/test_scoring_io.py
+++ b/tests/test_scoring_io.py
@@ -14,7 +14,9 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from utils.scoring import (
+    generate_challenge_region_bed,
     generate_synthetic_regions_bed,
+    parse_region_overcall_metrics,
     parse_happy_vcf_assessed_metrics,
     HappyScorer,
     subset_bed,
@@ -162,6 +164,30 @@ class TestGenerateSyntheticRegionsBed:
 
 
 # ---------------------------------------------------------------------------
+# TestGenerateChallengeRegionBed
+# ---------------------------------------------------------------------------
+
+class TestGenerateChallengeRegionBed:
+    """Tests for generate_challenge_region_bed."""
+
+    def test_valid_region(self, tmp_path):
+        bed = tmp_path / "challenge.bed"
+
+        result = generate_challenge_region_bed("chr20:20822504-25822504", str(bed))
+
+        assert result is True
+        assert _read_bed(bed) == [("chr20", 20822503, 25822504)]
+
+    def test_invalid_region(self, tmp_path):
+        bed = tmp_path / "challenge.bed"
+
+        result = generate_challenge_region_bed("chr20", str(bed))
+
+        assert result is False
+        assert not bed.exists()
+
+
+# ---------------------------------------------------------------------------
 # TestSubsetBed
 # ---------------------------------------------------------------------------
 
@@ -258,6 +284,72 @@ class TestParseHappyVcfAssessedMetrics:
         """Non-existent file returns None."""
         result = parse_happy_vcf_assessed_metrics(str(tmp_path / "nonexistent.vcf.gz"))
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TestParseRegionOvercallMetrics
+# ---------------------------------------------------------------------------
+
+class TestParseRegionOvercallMetrics:
+    """Tests for parse_region_overcall_metrics."""
+
+    def test_counts_full_region_query_fps_without_penalty_below_gate(self, tmp_path):
+        vcf = tmp_path / "happy_output.vcf.gz"
+        _write_happy_vcf(vcf, [
+            "chr20\t10000100\t.\tA\tG\t50\tPASS\t.\tBD:BVT\tTP:SNP\tFP:SNP\n",
+            "chr20\t10000200\t.\tA\tAT\t50\tPASS\t.\tBD:BVT\tTP:INDEL\tFP:INDEL\n",
+            "chr20\t10000300\t.\tC\tT\t50\tPASS\t.\tBD:BVT\tTP:SNP\tTP:SNP\n",
+            "chr20\t10000400\t.\tG\tA\t50\tPASS\t.\tBD:BVT\tTP:SNP\tUNK:SNP\n",
+        ])
+
+        result = parse_region_overcall_metrics(
+            str(vcf),
+            synthetic_truth_total=10,
+            synthetic_snp_truth_total=8,
+        )
+
+        assert result is not None
+        assert result["region_fp_snp"] == 1
+        assert result["region_fp_indel"] == 1
+        assert result["region_fp_total"] == 2
+        assert result["fp_per_target"] == pytest.approx(0.2)
+        assert result["snp_fp_per_target"] == pytest.approx(0.125)
+        assert result["overcall_penalty"] == 0.0
+
+    def test_penalty_requires_total_and_snp_gates(self, tmp_path):
+        vcf = tmp_path / "happy_output.vcf.gz"
+        _write_happy_vcf(vcf, [
+            "chr20\t10000100\t.\tA\tG\t50\tPASS\t.\tBD:BVT\tTP:SNP\tFP:SNP\n",
+        ] * 12)
+
+        result = parse_region_overcall_metrics(
+            str(vcf),
+            synthetic_truth_total=1,
+            synthetic_snp_truth_total=1,
+        )
+
+        assert result is not None
+        assert result["region_fp_total"] == 12
+        assert result["fp_per_target"] == pytest.approx(12.0)
+        assert result["snp_fp_per_target"] == pytest.approx(12.0)
+        assert result["overcall_penalty"] == pytest.approx(8.0)
+
+    def test_no_penalty_when_snp_gate_not_met(self, tmp_path):
+        vcf = tmp_path / "happy_output.vcf.gz"
+        _write_happy_vcf(vcf, [
+            "chr20\t10000100\t.\tA\tAT\t50\tPASS\t.\tBD:BVT\tTP:INDEL\tFP:INDEL\n",
+        ] * 12)
+
+        result = parse_region_overcall_metrics(
+            str(vcf),
+            synthetic_truth_total=1,
+            synthetic_snp_truth_total=1,
+        )
+
+        assert result is not None
+        assert result["fp_per_target"] == pytest.approx(12.0)
+        assert result["snp_fp_per_target"] == 0.0
+        assert result["overcall_penalty"] == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/utils/scoring.py
+++ b/utils/scoring.py
@@ -208,6 +208,32 @@ def generate_synthetic_regions_bed(truth_vcf: str, output_bed: str, padding: int
         return False
 
 
+def generate_challenge_region_bed(region: str, output_bed: str) -> bool:
+    """Create a BED file covering the full challenge region."""
+    try:
+        region_check = validate_region(region)
+        if not region_check["valid"]:
+            logger.error(f"Invalid challenge region '{region}': {region_check['error']}")
+            return False
+
+        chrom, coords = region.split(":")
+        start_str, end_str = coords.split("-")
+        start = int(start_str.replace(",", ""))
+        end = int(end_str.replace(",", ""))
+
+        output_path = Path(output_bed)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, 'w') as f:
+            f.write(f"{chrom}\t{max(0, start - 1)}\t{end}\n")
+
+        logger.info(f"Generated full challenge region BED: {region}")
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to generate challenge region BED: {e}")
+        return False
+
+
 def compute_synthetic_only_metrics(happy_vcf_path: str, mutations_vcf_path: str,
                                     position_tolerance: int = 10) -> Optional[Dict[str, float]]:
     """Filter hap.py results to only count variants matching the mutations VCF.
@@ -313,6 +339,68 @@ def compute_synthetic_only_metrics(happy_vcf_path: str, mutations_vcf_path: str,
     except Exception as e:
         logger.error(f"Failed to compute filtered metrics: {e}")
         logger.debug(traceback.format_exc())
+        return None
+
+
+def parse_region_overcall_metrics(happy_vcf_path: str,
+                                  synthetic_truth_total: float,
+                                  synthetic_snp_truth_total: float) -> Optional[Dict[str, float]]:
+    """Count full-region query false positives for the overcall guardrail."""
+    try:
+        vcf_path = Path(happy_vcf_path)
+        if not vcf_path.exists():
+            logger.warning(f"hap.py VCF not found: {vcf_path}")
+            return None
+
+        counts = {
+            'region_fp_snp': 0,
+            'region_fp_indel': 0,
+        }
+
+        opener = gzip.open if str(vcf_path).endswith('.gz') else open
+        with opener(vcf_path, 'rt') as f:
+            for line in f:
+                if line.startswith('#'):
+                    continue
+                fields = line.strip().split('\t')
+                if len(fields) < 11:
+                    continue
+
+                fmt_keys = fields[8].split(':')
+                fmt_query = dict(zip(fmt_keys, fields[10].split(':')))
+                bd_query = fmt_query.get('BD', '.')
+                bvt_query = fmt_query.get('BVT', '.')
+
+                if bd_query == 'FP':
+                    if bvt_query == 'SNP':
+                        counts['region_fp_snp'] += 1
+                    elif bvt_query == 'INDEL':
+                        counts['region_fp_indel'] += 1
+
+        region_fp_total = counts['region_fp_snp'] + counts['region_fp_indel']
+        fp_per_target = region_fp_total / max(float(synthetic_truth_total), 1.0)
+        snp_fp_per_target = counts['region_fp_snp'] / max(float(synthetic_snp_truth_total), 1.0)
+        if fp_per_target > 10.0 and snp_fp_per_target > 6.0:
+            overcall_penalty = min(45.0, (fp_per_target - 10.0) * 4.0)
+        else:
+            overcall_penalty = 0.0
+
+        logger.info(f"Overcall guardrail: region_fp={region_fp_total}, "
+                    f"fp_per_target={fp_per_target:.2f}, "
+                    f"snp_fp_per_target={snp_fp_per_target:.2f}, "
+                    f"penalty={overcall_penalty:.2f}")
+
+        return {
+            'region_fp_snp': float(counts['region_fp_snp']),
+            'region_fp_indel': float(counts['region_fp_indel']),
+            'region_fp_total': float(region_fp_total),
+            'fp_per_target': fp_per_target,
+            'snp_fp_per_target': snp_fp_per_target,
+            'overcall_penalty': overcall_penalty,
+        }
+
+    except Exception as e:
+        logger.warning(f"Failed to parse region overcall metrics: {e}")
         return None
 
 
@@ -558,15 +646,25 @@ class HappyScorer:
                 else:
                     logger.warning(f"Failed to slice truth VCF, using full chromosome VCF")
 
-            # Restrict scoring to synthetic mutation regions only
-            # This focuses hap.py on injected mutations, ignoring GIAB "free answers"
-            synthetic_bed = output_dir / f"synthetic_regions_{unique_suffix}.bed"
-            if generate_synthetic_regions_bed(str(truth_vcf), str(synthetic_bed)):
-                bed_path = synthetic_bed
-                use_bed = True
-                logger.info(f"Scoring restricted to synthetic mutation regions")
+            # With mutations_vcf, assess the full challenge region so overcalls are
+            # classified as FP instead of UNK. Synthetic scoring below still uses
+            # mutations_vcf to restrict TP/FN scoring to injected targets.
+            if mutations_vcf and region:
+                challenge_bed = output_dir / f"challenge_region_{region_slug}_{unique_suffix}.bed"
+                if generate_challenge_region_bed(region, str(challenge_bed)):
+                    bed_path = challenge_bed
+                    use_bed = True
+                    logger.info(f"Scoring full challenge region for overcall guardrail")
+                else:
+                    logger.warning("Could not generate challenge region BED, scoring full region")
             else:
-                logger.warning("Could not generate synthetic regions BED, scoring full region")
+                synthetic_bed = output_dir / f"synthetic_regions_{unique_suffix}.bed"
+                if generate_synthetic_regions_bed(str(truth_vcf), str(synthetic_bed)):
+                    bed_path = synthetic_bed
+                    use_bed = True
+                    logger.info(f"Scoring restricted to synthetic mutation regions")
+                else:
+                    logger.warning("Could not generate synthetic regions BED, scoring full region")
 
             # Use miner's VCF as-is without normalization
             # We score the exact output the miner provides - no modifications
@@ -762,6 +860,17 @@ class HappyScorer:
                         logger.error("Failed to compute filtered metrics from hap.py output")
                         return self._get_zero_scores()
                     happy_results.update(synthetic_metrics)
+                    synthetic_truth_total = (
+                        synthetic_metrics.get('truth_total_snp', 0.0) +
+                        synthetic_metrics.get('truth_total_indel', 0.0)
+                    )
+                    overcall_metrics = parse_region_overcall_metrics(
+                        str(happy_vcf),
+                        synthetic_truth_total,
+                        synthetic_metrics.get('truth_total_snp', 0.0)
+                    )
+                    if overcall_metrics:
+                        happy_results.update(overcall_metrics)
                     logger.info(f"Filtered metrics: SNP F1={synthetic_metrics['f1_snp']:.3f}, "
                                 f"INDEL F1={synthetic_metrics['f1_indel']:.3f}")
 
@@ -916,7 +1025,8 @@ class AdvancedScorer:
             0.10 * quality_component
         )
 
-        return final_score
+        overcall_penalty = metrics.get('overcall_penalty', 0.0)
+        return max(0.0, final_score - overcall_penalty)
 
 
 def parse_happy_vcf(vcf_path: str, truth_vcf_path: str = None) -> List[Dict[str, Any]]:


### PR DESCRIPTION

Adds a one-pass scoring guardrail for excessive regional overcalling while preserving synthetic-target scoring to avoid overcall.

The scorer now runs hap.py over the full region, then still uses mutations to compute synthetic-only target metrics that we care about. A separate overcall guardrail parses the same hap.py output and applies a penalty only when both total regional FP load and SNP FP load are high which indicates overcalling as a way to get higher score without being more accurate.