### PR TITLE
0.1.1

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,4 +6,4 @@ Miners run GATK, DeepVariant, FreeBayes, or BCFtools to call variants;
 validators score results with hap.py.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/neurons/__init__.py
+++ b/neurons/__init__.py
@@ -7,7 +7,7 @@ Miner and Validator are meant to be run as scripts via:
 They are not imported as library components.
 """
 
-MINOS_SPEC_VERSION = "0.1.0"
+MINOS_SPEC_VERSION = "0.1.1"
 SPEC_STRING = MINOS_SPEC_VERSION.split(".")
 SPEC_VERSION_MAJOR = 100*int(SPEC_STRING[0])
 SPEC_VERSION_MINOR = 10*int(SPEC_STRING[1])

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -1186,10 +1186,18 @@ class Validator:
 
             # Apply burn split: scale miners to (1 - burn_rate), give burn the
             # rest. Falls through to 100% burn if no miner has weight.
-            burn_rate = GENOMICS_CONFIG.get("burn_rate", 0.0) or 0.0
+            # burn_rate from platform if available, else BURN_RATE env.
+            network_cfg = await self.platform_client.get_network_config()
+            if network_cfg and "burn_rate" in network_cfg:
+                burn_rate = float(network_cfg["burn_rate"])
+                burn_uid = int(network_cfg.get("burn_uid", 0))
+            else:
+                burn_rate = float(GENOMICS_CONFIG.get("burn_rate", 0.9))
+                burn_uid = 0
+            burn_rate = max(0.0, min(1.0, burn_rate))
             burn_hotkey = ""
-            if burn_rate > 0 and len(self.metagraph.hotkeys) > 0:
-                burn_hotkey = self.metagraph.hotkeys[0]
+            if burn_rate > 0 and len(self.metagraph.hotkeys) > burn_uid:
+                burn_hotkey = self.metagraph.hotkeys[burn_uid]
                 if sum(weights.values()) > 0:
                     scale = 1.0 - burn_rate
                     for hk in list(weights.keys()):
@@ -1197,7 +1205,7 @@ class Validator:
                     weights[burn_hotkey] = burn_rate
                 else:
                     weights[burn_hotkey] = 1.0
-                bt.logging.info(f"burn {burn_rate * 100:.0f}% -> uid 0 ({burn_hotkey[:12]}...)")
+                bt.logging.info(f"burn {burn_rate * 100:.0f}% -> uid {burn_uid} ({burn_hotkey[:12]}...)")
 
             # Log weight distribution (mode-aware)
             stats = self.score_tracker.get_stats()

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -825,6 +825,12 @@ class Validator:
                 happy_output_s3_key=happy_output_s3_key,
             )
 
+            if metrics is None:
+                print("   Scoring failed; submitted score 0.0", flush=True)
+                self.score_tracker.update(miner_hotkey, 0.0)
+                scored_hotkeys.append(miner_hotkey)
+                return
+
             # 8. Parse and submit variant-level results (non-blocking).
             # The validator gzips the per-variant breakdown locally, uploads
             # it via /v2/get-upload-url (R2 -> Hippius -> AWS cascade decided

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -3,6 +3,7 @@
 import sys
 import os
 import gzip
+import math
 import shutil
 import traceback
 import subprocess
@@ -1033,6 +1034,45 @@ class Validator:
         Returns:
             Dict with score_id on success, None on failure.
         """
+        def _json_safe_float(value):
+            try:
+                number = float(value)
+            except (TypeError, ValueError):
+                return None
+            if not math.isfinite(number):
+                return None
+            return number
+
+        def _build_advanced_metrics_payload(
+            source_metrics: dict,
+            advanced_score: float,
+            combined_final: float,
+            snp_final: float,
+            indel_final: float,
+        ) -> dict:
+            payload = {
+                "scorer": "Advanced",
+                "score_schema_version": "0.1.1",
+                "scoring_status": "scored",
+                "advanced_score": advanced_score,
+                "combined_final": combined_final,
+                "snp_final": snp_final,
+                "indel_final": indel_final,
+            }
+
+            for key, value in (source_metrics or {}).items():
+                number = _json_safe_float(value)
+                if number is not None:
+                    payload[key] = number
+
+            # Keep the canonical aliases explicit even if source_metrics had
+            # missing or non-finite values.
+            payload["advanced_score"] = advanced_score
+            payload["combined_final"] = combined_final
+            payload["snp_final"] = snp_final
+            payload["indel_final"] = indel_final
+            return payload
+
         try:
             if metrics is None:
                 # Failed run - submit zeros
@@ -1040,7 +1080,28 @@ class Validator:
                     round_id=round_id,
                     miner_hotkey=miner_hotkey,
                     snp_f1=0.0,
+                    snp_precision=0.0,
+                    snp_recall=0.0,
+                    snp_tp=0,
+                    snp_fp=0,
+                    snp_fn=0,
                     indel_f1=0.0,
+                    indel_precision=0.0,
+                    indel_recall=0.0,
+                    indel_tp=0,
+                    indel_fp=0,
+                    indel_fn=0,
+                    additional_metrics={
+                        "scorer": "Advanced",
+                        "score_schema_version": "0.1.1",
+                        "scoring_status": "failed",
+                        "advanced_score": 0.0,
+                        "combined_final": 0.0,
+                        "snp_final": 0.0,
+                        "indel_final": 0.0,
+                        "weighted_f1": 0.0,
+                        "overcall_penalty": 0.0,
+                    },
                     validation_runtime_seconds=validation_runtime
                 )
             else:
@@ -1069,15 +1130,13 @@ class Validator:
                     indel_fn=metrics.get("fn_indel"),
                     ti_tv_ratio=metrics.get("titv_query_snp"),
                     het_hom_ratio=metrics.get("hethom_query_snp"),
-                    additional_metrics={
-                        "scorer": "Advanced",
-                        "weighted_f1": metrics.get("weighted_f1"),
-                        "frac_na_snp": metrics.get("frac_na_snp"),
-                        "frac_na_indel": metrics.get("frac_na_indel"),
-                        "snp_final": snp_final,
-                        "indel_final": indel_final,
-                        "combined_final": combined_final,
-                    },
+                    additional_metrics=_build_advanced_metrics_payload(
+                        metrics,
+                        advanced_score,
+                        combined_final,
+                        snp_final,
+                        indel_final,
+                    ),
                     validation_runtime_seconds=validation_runtime,
                     output_vcf_s3_key=output_vcf_s3_key,
                     output_vcf_sha256=output_vcf_sha256,

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -463,8 +463,13 @@ class Validator:
             if already_scored:
                 print(f"   Restart recovery: {len(already_scored)} miners already scored, skipping", flush=True)
                 for hotkey, score_info in already_scored.items():
-                    combined_final = score_info.get("combined_final", 0.0)
-                    self.score_tracker.update(hotkey, combined_final if combined_final is not None else 0.0)
+                    combined_final = score_info.get("combined_final")
+                    if combined_final is None:
+                        bt.logging.warning(
+                            f"Skipping restored score for {hotkey[:16]}...: missing AdvancedScorer combined_final"
+                        )
+                        continue
+                    self.score_tracker.update(hotkey, combined_final)
                     scored_hotkeys.append(hotkey)
                     bt.logging.info(f"Restored score for {hotkey[:16]}...: combined_final={combined_final}")
 
@@ -905,7 +910,12 @@ class Validator:
                 # --- Step 3: Feed backfill into ScoreTracker ---
                 for entry in backfill_scores:
                     hk = entry.get("miner_hotkey")
-                    combined_final = entry.get("combined_final", 0.0)
+                    combined_final = entry.get("combined_final")
+                    if combined_final is None:
+                        bt.logging.warning(
+                            f"Skipping backfill for {hk[:16] if hk else '?'}...: missing AdvancedScorer combined_final"
+                        )
+                        continue
                     if hk and hk not in set(all_scored_hotkeys):
                         self.score_tracker.update(hk, combined_final)
                         all_scored_hotkeys.append(hk)

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -111,6 +111,16 @@ class TestComputeAdvancedScore:
         # Should be a good but not perfect score
         assert score > 50.0
 
+    def test_overcall_penalty_subtracted(self, sample_happy_metrics):
+        """Overcall guardrail penalty should be subtracted from final score."""
+        base_score = AdvancedScorer.compute_advanced_score(sample_happy_metrics)
+        metrics = dict(sample_happy_metrics)
+        metrics["overcall_penalty"] = 12.5
+
+        penalized_score = AdvancedScorer.compute_advanced_score(metrics)
+
+        assert penalized_score == pytest.approx(max(0.0, base_score - 12.5))
+
     def test_snp_only_truth_weighting(self):
         """When truth_total_indel=0, weighting should only use SNP F1."""
         metrics = {

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -142,8 +142,8 @@ class TestComputeAdvancedScore:
         # The indel F1 of 0.50 should NOT drag the score down
         assert score > 60.0
 
-    def test_no_truth_totals_fallback_weighting(self):
-        """When both truth totals are 0, should fall back to 0.7*snp + 0.3*indel."""
+    def test_no_truth_totals_fail_closed(self):
+        """When both truth totals are 0, AdvancedScorer should fail closed."""
         metrics = {
             'f1_snp': 0.90,
             'f1_indel': 0.80,
@@ -159,13 +159,7 @@ class TestComputeAdvancedScore:
             'frac_na_indel': 0.0,
         }
         score = AdvancedScorer.compute_advanced_score(metrics)
-        # Fallback weighted_f1 = 0.7*0.9 + 0.3*0.8 = 0.87
-        # core_component = emphasis(0.87, 0.5)
-        expected_weighted_f1 = 0.7 * 0.90 + 0.3 * 0.80
-        expected_core = AdvancedScorer.emphasis(expected_weighted_f1, gamma=0.5)
-        # Just verify the score is reasonable and reflects that core component
-        assert score > 40.0
-        assert score <= 100.0
+        assert score == 0.0
 
     def test_high_f1_high_fp_penalized(self):
         """High F1 but many false positives should penalize the FP component."""
@@ -377,21 +371,8 @@ class TestComputeAdvancedScore:
 class TestHappyScorerZeroScores:
     """Tests for HappyScorer._get_zero_scores()."""
 
-    def test_zero_scores_expected_keys(self):
-        """_get_zero_scores should return the expected set of keys."""
+    def test_zero_scores_returns_failed_sentinel(self):
+        """_get_zero_scores should fail closed and let the validator submit 0."""
         scorer = HappyScorer()
         result = scorer._get_zero_scores()
-        expected_keys = {
-            'f1_snp', 'f1_indel',
-            'precision_snp', 'recall_snp',
-            'precision_indel', 'recall_indel',
-            'weighted_f1',
-        }
-        assert set(result.keys()) == expected_keys
-
-    def test_zero_scores_all_zero(self):
-        """All values in _get_zero_scores should be 0.0."""
-        scorer = HappyScorer()
-        result = scorer._get_zero_scores()
-        for key, value in result.items():
-            assert value == 0.0, f"Expected 0.0 for key '{key}', got {value}"
+        assert result is None

--- a/tests/test_scoring_io.py
+++ b/tests/test_scoring_io.py
@@ -14,7 +14,9 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from utils.scoring import (
+    generate_challenge_region_bed,
     generate_synthetic_regions_bed,
+    parse_region_overcall_metrics,
     parse_happy_vcf_assessed_metrics,
     HappyScorer,
     subset_bed,
@@ -162,6 +164,30 @@ class TestGenerateSyntheticRegionsBed:
 
 
 # ---------------------------------------------------------------------------
+# TestGenerateChallengeRegionBed
+# ---------------------------------------------------------------------------
+
+class TestGenerateChallengeRegionBed:
+    """Tests for generate_challenge_region_bed."""
+
+    def test_valid_region(self, tmp_path):
+        bed = tmp_path / "challenge.bed"
+
+        result = generate_challenge_region_bed("chr20:20822504-25822504", str(bed))
+
+        assert result is True
+        assert _read_bed(bed) == [("chr20", 20822503, 25822504)]
+
+    def test_invalid_region(self, tmp_path):
+        bed = tmp_path / "challenge.bed"
+
+        result = generate_challenge_region_bed("chr20", str(bed))
+
+        assert result is False
+        assert not bed.exists()
+
+
+# ---------------------------------------------------------------------------
 # TestSubsetBed
 # ---------------------------------------------------------------------------
 
@@ -258,6 +284,72 @@ class TestParseHappyVcfAssessedMetrics:
         """Non-existent file returns None."""
         result = parse_happy_vcf_assessed_metrics(str(tmp_path / "nonexistent.vcf.gz"))
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TestParseRegionOvercallMetrics
+# ---------------------------------------------------------------------------
+
+class TestParseRegionOvercallMetrics:
+    """Tests for parse_region_overcall_metrics."""
+
+    def test_counts_full_region_query_fps_without_penalty_below_gate(self, tmp_path):
+        vcf = tmp_path / "happy_output.vcf.gz"
+        _write_happy_vcf(vcf, [
+            "chr20\t10000100\t.\tA\tG\t50\tPASS\t.\tBD:BVT\tTP:SNP\tFP:SNP\n",
+            "chr20\t10000200\t.\tA\tAT\t50\tPASS\t.\tBD:BVT\tTP:INDEL\tFP:INDEL\n",
+            "chr20\t10000300\t.\tC\tT\t50\tPASS\t.\tBD:BVT\tTP:SNP\tTP:SNP\n",
+            "chr20\t10000400\t.\tG\tA\t50\tPASS\t.\tBD:BVT\tTP:SNP\tUNK:SNP\n",
+        ])
+
+        result = parse_region_overcall_metrics(
+            str(vcf),
+            synthetic_truth_total=10,
+            synthetic_snp_truth_total=8,
+        )
+
+        assert result is not None
+        assert result["region_fp_snp"] == 1
+        assert result["region_fp_indel"] == 1
+        assert result["region_fp_total"] == 2
+        assert result["fp_per_target"] == pytest.approx(0.2)
+        assert result["snp_fp_per_target"] == pytest.approx(0.125)
+        assert result["overcall_penalty"] == 0.0
+
+    def test_penalty_requires_total_and_snp_gates(self, tmp_path):
+        vcf = tmp_path / "happy_output.vcf.gz"
+        _write_happy_vcf(vcf, [
+            "chr20\t10000100\t.\tA\tG\t50\tPASS\t.\tBD:BVT\tTP:SNP\tFP:SNP\n",
+        ] * 12)
+
+        result = parse_region_overcall_metrics(
+            str(vcf),
+            synthetic_truth_total=1,
+            synthetic_snp_truth_total=1,
+        )
+
+        assert result is not None
+        assert result["region_fp_total"] == 12
+        assert result["fp_per_target"] == pytest.approx(12.0)
+        assert result["snp_fp_per_target"] == pytest.approx(12.0)
+        assert result["overcall_penalty"] == pytest.approx(8.0)
+
+    def test_no_penalty_when_snp_gate_not_met(self, tmp_path):
+        vcf = tmp_path / "happy_output.vcf.gz"
+        _write_happy_vcf(vcf, [
+            "chr20\t10000100\t.\tA\tAT\t50\tPASS\t.\tBD:BVT\tTP:INDEL\tFP:INDEL\n",
+        ] * 12)
+
+        result = parse_region_overcall_metrics(
+            str(vcf),
+            synthetic_truth_total=1,
+            synthetic_snp_truth_total=1,
+        )
+
+        assert result is not None
+        assert result["fp_per_target"] == pytest.approx(12.0)
+        assert result["snp_fp_per_target"] == 0.0
+        assert result["overcall_penalty"] == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scoring_io.py
+++ b/tests/test_scoring_io.py
@@ -441,8 +441,4 @@ class TestHappyScorerCsvParsing:
                 reference_sdf=str(sdf_dir),
             )
 
-        expected_zero = scorer._get_zero_scores()
-        assert result == expected_zero
-        assert result["f1_snp"] == 0.0
-        assert result["f1_indel"] == 0.0
-        assert result["weighted_f1"] == 0.0
+        assert result is None

--- a/utils/platform_client.py
+++ b/utils/platform_client.py
@@ -134,6 +134,18 @@ class PlatformClient:
         except Exception:
             return False
 
+    async def get_network_config(self) -> Optional[Dict[str, Any]]:
+        """Fetch network reward params (burn_rate, burn_uid). Returns None on
+        any error so the caller can fall back to env defaults."""
+        try:
+            async with self._get_client() as client:
+                response = await client.get("/scoring/network-config")
+                if response.status_code == 200:
+                    return response.json()
+                return None
+        except Exception:
+            return None
+
 
 class MinerPlatformClient(PlatformClient):
     """Platform client for miners."""

--- a/utils/scoring.py
+++ b/utils/scoring.py
@@ -208,6 +208,32 @@ def generate_synthetic_regions_bed(truth_vcf: str, output_bed: str, padding: int
         return False
 
 
+def generate_challenge_region_bed(region: str, output_bed: str) -> bool:
+    """Create a BED file covering the full challenge region."""
+    try:
+        region_check = validate_region(region)
+        if not region_check["valid"]:
+            logger.error(f"Invalid challenge region '{region}': {region_check['error']}")
+            return False
+
+        chrom, coords = region.split(":")
+        start_str, end_str = coords.split("-")
+        start = int(start_str.replace(",", ""))
+        end = int(end_str.replace(",", ""))
+
+        output_path = Path(output_bed)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, 'w') as f:
+            f.write(f"{chrom}\t{max(0, start - 1)}\t{end}\n")
+
+        logger.info(f"Generated full challenge region BED: {region}")
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to generate challenge region BED: {e}")
+        return False
+
+
 def compute_synthetic_only_metrics(happy_vcf_path: str, mutations_vcf_path: str,
                                     position_tolerance: int = 10) -> Optional[Dict[str, float]]:
     """Filter hap.py results to only count variants matching the mutations VCF.
@@ -313,6 +339,68 @@ def compute_synthetic_only_metrics(happy_vcf_path: str, mutations_vcf_path: str,
     except Exception as e:
         logger.error(f"Failed to compute filtered metrics: {e}")
         logger.debug(traceback.format_exc())
+        return None
+
+
+def parse_region_overcall_metrics(happy_vcf_path: str,
+                                  synthetic_truth_total: float,
+                                  synthetic_snp_truth_total: float) -> Optional[Dict[str, float]]:
+    """Count full-region query false positives for the overcall guardrail."""
+    try:
+        vcf_path = Path(happy_vcf_path)
+        if not vcf_path.exists():
+            logger.warning(f"hap.py VCF not found: {vcf_path}")
+            return None
+
+        counts = {
+            'region_fp_snp': 0,
+            'region_fp_indel': 0,
+        }
+
+        opener = gzip.open if str(vcf_path).endswith('.gz') else open
+        with opener(vcf_path, 'rt') as f:
+            for line in f:
+                if line.startswith('#'):
+                    continue
+                fields = line.strip().split('\t')
+                if len(fields) < 11:
+                    continue
+
+                fmt_keys = fields[8].split(':')
+                fmt_query = dict(zip(fmt_keys, fields[10].split(':')))
+                bd_query = fmt_query.get('BD', '.')
+                bvt_query = fmt_query.get('BVT', '.')
+
+                if bd_query == 'FP':
+                    if bvt_query == 'SNP':
+                        counts['region_fp_snp'] += 1
+                    elif bvt_query == 'INDEL':
+                        counts['region_fp_indel'] += 1
+
+        region_fp_total = counts['region_fp_snp'] + counts['region_fp_indel']
+        fp_per_target = region_fp_total / max(float(synthetic_truth_total), 1.0)
+        snp_fp_per_target = counts['region_fp_snp'] / max(float(synthetic_snp_truth_total), 1.0)
+        if fp_per_target > 10.0 and snp_fp_per_target > 6.0:
+            overcall_penalty = min(45.0, (fp_per_target - 10.0) * 4.0)
+        else:
+            overcall_penalty = 0.0
+
+        logger.info(f"Overcall guardrail: region_fp={region_fp_total}, "
+                    f"fp_per_target={fp_per_target:.2f}, "
+                    f"snp_fp_per_target={snp_fp_per_target:.2f}, "
+                    f"penalty={overcall_penalty:.2f}")
+
+        return {
+            'region_fp_snp': float(counts['region_fp_snp']),
+            'region_fp_indel': float(counts['region_fp_indel']),
+            'region_fp_total': float(region_fp_total),
+            'fp_per_target': fp_per_target,
+            'snp_fp_per_target': snp_fp_per_target,
+            'overcall_penalty': overcall_penalty,
+        }
+
+    except Exception as e:
+        logger.warning(f"Failed to parse region overcall metrics: {e}")
         return None
 
 
@@ -558,15 +646,25 @@ class HappyScorer:
                 else:
                     logger.warning(f"Failed to slice truth VCF, using full chromosome VCF")
 
-            # Restrict scoring to synthetic mutation regions only
-            # This focuses hap.py on injected mutations, ignoring GIAB "free answers"
-            synthetic_bed = output_dir / f"synthetic_regions_{unique_suffix}.bed"
-            if generate_synthetic_regions_bed(str(truth_vcf), str(synthetic_bed)):
-                bed_path = synthetic_bed
-                use_bed = True
-                logger.info(f"Scoring restricted to synthetic mutation regions")
+            # With mutations_vcf, assess the full challenge region so overcalls are
+            # classified as FP instead of UNK. Synthetic scoring below still uses
+            # mutations_vcf to restrict TP/FN scoring to injected targets.
+            if mutations_vcf and region:
+                challenge_bed = output_dir / f"challenge_region_{region_slug}_{unique_suffix}.bed"
+                if generate_challenge_region_bed(region, str(challenge_bed)):
+                    bed_path = challenge_bed
+                    use_bed = True
+                    logger.info(f"Scoring full challenge region for overcall guardrail")
+                else:
+                    logger.warning("Could not generate challenge region BED, scoring full region")
             else:
-                logger.warning("Could not generate synthetic regions BED, scoring full region")
+                synthetic_bed = output_dir / f"synthetic_regions_{unique_suffix}.bed"
+                if generate_synthetic_regions_bed(str(truth_vcf), str(synthetic_bed)):
+                    bed_path = synthetic_bed
+                    use_bed = True
+                    logger.info(f"Scoring restricted to synthetic mutation regions")
+                else:
+                    logger.warning("Could not generate synthetic regions BED, scoring full region")
 
             # Use miner's VCF as-is without normalization
             # We score the exact output the miner provides - no modifications
@@ -762,6 +860,17 @@ class HappyScorer:
                         logger.error("Failed to compute filtered metrics from hap.py output")
                         return self._get_zero_scores()
                     happy_results.update(synthetic_metrics)
+                    synthetic_truth_total = (
+                        synthetic_metrics.get('truth_total_snp', 0.0) +
+                        synthetic_metrics.get('truth_total_indel', 0.0)
+                    )
+                    overcall_metrics = parse_region_overcall_metrics(
+                        str(happy_vcf),
+                        synthetic_truth_total,
+                        synthetic_metrics.get('truth_total_snp', 0.0)
+                    )
+                    if overcall_metrics:
+                        happy_results.update(overcall_metrics)
                     logger.info(f"Filtered metrics: SNP F1={synthetic_metrics['f1_snp']:.3f}, "
                                 f"INDEL F1={synthetic_metrics['f1_indel']:.3f}")
 
@@ -916,7 +1025,8 @@ class AdvancedScorer:
             0.10 * quality_component
         )
 
-        return final_score
+        overcall_penalty = metrics.get('overcall_penalty', 0.0)
+        return max(0.0, final_score - overcall_penalty)
 
 
 def parse_happy_vcf(vcf_path: str, truth_vcf_path: str = None) -> List[Dict[str, Any]]:

--- a/utils/scoring.py
+++ b/utils/scoring.py
@@ -266,6 +266,9 @@ def compute_synthetic_only_metrics(happy_vcf_path: str, mutations_vcf_path: str,
 
         logger.info(f"Loaded {len(target_snps)} target SNPs and "
                      f"{len(target_indel_positions)} target INDELs from {mutations_path.name}")
+        if not target_snps and not target_indel_positions:
+            logger.error(f"No target mutations found in {mutations_path.name}")
+            return None
 
         counts = {
             'tp_snp': 0, 'fp_snp': 0, 'fn_snp': 0,
@@ -545,7 +548,7 @@ class HappyScorer:
     def score_vcf(self, truth_vcf: str, query_vcf: str,
                   reference_fasta: str = None, confident_bed: str = None,
                   region: str = None, reference_sdf: str = None,
-                  mutations_vcf: str = None) -> Dict[str, float]:
+                  mutations_vcf: str = None) -> Optional[Dict[str, float]]:
         """Run hap.py and return precision/recall/F1 metrics.
 
         Args:
@@ -644,6 +647,9 @@ class HappyScorer:
                     truth_vcf = sliced_truth_vcf
                     logger.info(f"Using sliced truth VCF: {truth_vcf.name}")
                 else:
+                    if mutations_vcf:
+                        logger.error("Failed to slice truth VCF for synthetic scoring; failing closed")
+                        return self._get_zero_scores()
                     logger.warning(f"Failed to slice truth VCF, using full chromosome VCF")
 
             # With mutations_vcf, assess the full challenge region so overcalls are
@@ -656,7 +662,8 @@ class HappyScorer:
                     use_bed = True
                     logger.info(f"Scoring full challenge region for overcall guardrail")
                 else:
-                    logger.warning("Could not generate challenge region BED, scoring full region")
+                    logger.error("Could not generate challenge region BED for overcall guardrail; failing closed")
+                    return self._get_zero_scores()
             else:
                 synthetic_bed = output_dir / f"synthetic_regions_{unique_suffix}.bed"
                 if generate_synthetic_regions_bed(str(truth_vcf), str(synthetic_bed)):
@@ -889,17 +896,9 @@ class HappyScorer:
             logger.debug(traceback.format_exc())
             return self._get_zero_scores()
 
-    def _get_zero_scores(self) -> Dict[str, float]:
-        """Return zero scores structure."""
-        return {
-            'f1_snp': 0.0,
-            'f1_indel': 0.0,
-            'precision_snp': 0.0,
-            'recall_snp': 0.0,
-            'precision_indel': 0.0,
-            'recall_indel': 0.0,
-            'weighted_f1': 0.0
-        }
+    def _get_zero_scores(self) -> Optional[Dict[str, float]]:
+        """Fail closed so the validator submits explicit combined_final=0.0."""
+        return None
 
 
 class AdvancedScorer:
@@ -966,11 +965,10 @@ class AdvancedScorer:
 
         # Component 1: Core F1 (60% weight) - truth-weighted F1 with emphasis
         total_truth = truth_total_snp + truth_total_indel
-        if total_truth > 0:
-            weighted_f1 = (f1_snp * truth_total_snp + f1_indel * truth_total_indel) / total_truth
-        else:
-            # Fallback to simple weighting if truth totals not available
-            weighted_f1 = 0.7 * f1_snp + 0.3 * f1_indel
+        if total_truth <= 0:
+            logger.error("AdvancedScorer missing truth totals; returning zero score")
+            return 0.0
+        weighted_f1 = (f1_snp * truth_total_snp + f1_indel * truth_total_indel) / total_truth
         core_component = AdvancedScorer.emphasis(weighted_f1, gamma=0.5)
 
         # Component 2: Completeness (15% weight) - recall + coverage


### PR DESCRIPTION
Release `0.1.1` validator/scoring update.

This aligns validator score submission around `AdvancedScorer` / `combined_final`, tightens failure behavior, and adds the overcall guardrail needed for the new scoring round for overcalling.

## Changes

- Bump subnet/spec version to `0.1.1`.
- Submit AdvancedScorer outputs explicitly to the platform:
  - `combined_final`
  - `advanced_score`
  - `snp_final`
  - `indel_final`
  - `score_schema_version`
  - `scoring_status`
- Stop defaulting missing `combined_final` to `0.0` during restart recovery/backfill; missing AdvancedScorer scores are skipped instead.
- Fail closed on incomplete scorer inputs:
  - hap.py/scoring failures now submit explicit `combined_final = 0.0`
  - missing truth totals return `0.0` instead of falling back to old weighted SNP/INDEL F1
  - synthetic truth slicing / challenge BED failures fail closed for production synthetic scoring
- Add overcall guardrail:
  - score hap.py over the full challenge region so extra calls are counted as FP instead of hidden as UNK
  - compute region-level FP metrics
  - apply overcall penalty for excessive calls relative to target truth variants
- Fetch burn config from platform via `/scoring/network-config`, with env/default fallback.
  - supports configurable `burn_rate`
  - supports configurable `burn_uid`
  - clamps burn rate to `[0, 1]`