### PR TITLE
feat: add miner deregistration pruning weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ minos_subnet/
 │   └── tool_params.py        # Parameter definitions and validation
 ├── utils/                    # Genomics utility modules
 │   ├── scoring.py            # hap.py Docker runner + AdvancedScorer
-│   ├── weight_tracking.py    # EMA score tracker + winner-takes-all weights
+│   ├── weight_tracking.py    # EMA score tracker + winner-heavy pruning dust weights
 │   ├── platform_client.py    # Authenticated API client (miner + validator)
 │   ├── subset_scoring.py     # Subset scoring helpers (assignments, deadlines)
 │   ├── config_loader.py      # Tool config file parser
@@ -433,9 +433,9 @@ ema = (1 - alpha) * ema + alpha * combined_final
 
 Weights are assigned in two phases:
 
-**Warmup** (before any miner has reached eligibility): reward is split among the top 3 active miners by EMA score — 50% to 1st, 30% to 2nd, 20% to 3rd. If fewer than three active miners have positive EMA, the split is renormalized across the active positive-score set.
+**Warmup** (before any miner has reached eligibility): the non-burn miner budget is split among the top 3 active miners by EMA score — 50% to 1st, 30% to 2nd, 20% to 3rd. If fewer than three active miners have positive EMA, the split is renormalized across the active positive-score set.
 
-**Normal** (once any miner reaches eligibility): the single top-performing eligible miner by EMA receives 100% of the weight. Eligibility requires scoring in at least 10 of the last 20 rounds. Miners below the participation threshold receive 0 weight in normal mode. Absent miners' EMA decays each round they miss (×0.95), preventing stale scores from holding weight indefinitely.
+**Normal** (once any miner reaches eligibility): validators burn 87% of their weight, give the top eligible miner 10%, and split the remaining 3% as ranked pruning dust across eligible ranks #2 through #10 using a 0.8 geometric decay. If fewer dust recipients exist, that 3% is renormalized across the available ranks; if no dust recipients exist, unused dust is sent to burn. Eligibility requires scoring in at least 10 of the last 20 rounds. Miners below the participation threshold receive 0 weight in normal mode. Absent miners' EMA decays each round they miss (×0.95), preventing stale scores from holding weight indefinitely.
 
 In the warmup phase, miners with scores within 0.5% of each other are tiebroken by earliest config submission time. In the normal phase, tiebreaks only apply when EMA scores are essentially identical (floating-point tolerance).
 

--- a/__init__.py
+++ b/__init__.py
@@ -6,4 +6,4 @@ Miners run GATK, DeepVariant, FreeBayes, or BCFtools to call variants;
 validators score results with hap.py.
 """
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/base/genomics_config.py
+++ b/base/genomics_config.py
@@ -31,8 +31,6 @@ GENOMICS_CONFIG = {
     "variant_calling_timeout": 7200 if is_local_network() else 3600,  # 2h local, 1h production
     "task_interval": int(os.getenv("TASK_INTERVAL", "600" if is_local_network() else "3600")),  # 10m local, 1h production
 
-    # Fraction of weight sent to UID 0 for burn. Set BURN_RATE=0 to disable.
-    "burn_rate": float(os.getenv("BURN_RATE", "0.9")),
 }
 
 # Validator specific settings

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,7 +128,7 @@ while True:
             update_ema(entry.hotkey, entry.score)
         record_round(personal_hotkeys + backfill_hotkeys)
 
-        weights = compute_weights()             # warmup split or winner-takes-all
+        weights = compute_weights()             # warmup split or winner-heavy pruning dust
         submit_weight_history(weights)          # platform dashboard/audit
         if registered_on_subnet:
             set_weights_on_chain(weights)       # Bittensor chain write
@@ -152,13 +152,13 @@ hap.py computes SNP and INDEL precision/recall against the truth VCF. The `Advan
 
 SNP/INDEL weighting is truth-count-proportional (fallback: 70/30).
 
-### 5.2 Weight assignment (EMA + winner-takes-all)
+### 5.2 Weight assignment (EMA + winner-heavy pruning dust)
 
 - Each scored round updates each miner's EMA: `ema = α × score + (1−α) × ema` (α = 0.1); EMA starts at 0 so the first round yields 10% of the first score
 - Miners must participate in ≥ 10 of the last 20 rounds to be eligible for weights
 - Missed rounds decay the EMA by 0.95× per missed round
-- **Warmup phase** (before any miner reaches 10 rounds): reward split 50/30/20 among the top 3 active miners with positive EMA; the split is renormalized if fewer than three qualify; tiebreak by earliest config submission time
-- **Normal phase** (once any miner reaches eligibility): the eligible miner with the highest EMA receives **100% of the weight** on-chain; tiebreak by earliest config submission time
+- **Warmup phase** (before any miner reaches 10 rounds): the non-burn miner budget is split 50/30/20 among the top 3 active miners with positive EMA; the split is renormalized if fewer than three qualify; tiebreak by earliest config submission time
+- **Normal phase** (once any miner reaches eligibility): 87% goes to the burn UID, the highest-EMA eligible miner receives 10%, and the remaining 3% is distributed as ranked pruning dust across eligible ranks #2 through #10 using geometric decay; tiebreak by earliest config submission time
 - Miners below the participation threshold receive 0 weight
 
 ---
@@ -193,7 +193,7 @@ minos_subnet/
 │   └── tool_params.py     # Parameter definitions and validation
 ├── utils/
 │   ├── scoring.py         # hap.py Docker runner + AdvancedScorer
-│   ├── weight_tracking.py # EMA score tracker + winner-takes-all weights
+│   ├── weight_tracking.py # EMA score tracker + winner-heavy pruning dust weights
 │   ├── platform_client.py # Authenticated API client (miner + validator)
 │   ├── subset_scoring.py  # Subset scoring helpers (assignments, deadlines)
 │   ├── config_loader.py   # Tool config file parser

--- a/docs/tuning_guide.md
+++ b/docs/tuning_guide.md
@@ -34,9 +34,9 @@ The AdvancedScorer outputs a raw score on a 0–100 scale. This is normalized to
 - Missing rounds applies a decay factor of 0.95 per missed round to your EMA.
 - When reading logs: `Score: 85.00/100  EMA: 0.0850` is a typical first-round result with alpha = 0.1. The score is 0–100; the EMA is 0–1 and moves gradually.
 
-**Warmup phase** (until any miner has participated in 10+ rounds): rewards are split among the top 3 active miners by EMA — 50% to 1st, 30% to 2nd, 20% to 3rd, renormalized if fewer than three active miners have positive EMA.
+**Warmup phase** (until any miner has participated in 10+ rounds): the non-burn miner budget is split among the top 3 active miners by EMA — 50% to 1st, 30% to 2nd, 20% to 3rd, renormalized if fewer than three active miners have positive EMA.
 
-**Normal phase** (after warmup): **winner-takes-all** among eligible miners — the eligible miner with the highest EMA gets 100% of emissions for that validator. Ineligible miners and second place get 0.
+**Normal phase** (after warmup): **winner-heavy with pruning dust** among eligible miners — validators burn 87%, give rank #1 10%, and split the remaining 3% across eligible ranks #2 through #10 with ranked decay. Ineligible miners and ranks below the dust cutoff get 0.
 
 Consistency matters as much as peak performance.
 
@@ -46,7 +46,7 @@ This is the most common question for new miners. There are three distinct causes
 
 **1. You are not eligible yet (most likely).** Eligibility requires participating in **at least 10 of the last 20 rounds**. With ~20 rounds per day, a fresh miner needs roughly 12 hours of continuous uptime before they can earn any weight, even with perfect scores. During this time you appear in validator logs but receive 0 weight. This is expected.
 
-**2. You are eligible but a competitor has a higher EMA.** Once eligible, weights are winner-takes-all. If another miner has a higher EMA than yours (even by a tiny margin), they get 100% and you get 0. The fix is to score better — see Section 4 (Tuning Strategy).
+**2. You are eligible but outside the paid ranks.** Once eligible, the top miner gets the main 10% miner weight and eligible ranks #2 through #10 split the pruning dust. If your EMA is below the paid cutoff, you get 0. The fix is to score better — see Section 4 (Tuning Strategy).
 
 **3. You are submitting but the score is 0.** Causes: wrong reference build, malformed VCF (multi-sample, missing index), tool config rejected by the parameter whitelist, or a Docker error. Check your logs for the line `Score: 0.00/100`. If you see it, the variant call ran but produced no usable output. If you do not see a score line at all, your submission never made it to the scoring phase — check the platform connectivity / round timing.
 
@@ -161,7 +161,7 @@ The scoring weights (60% F1, 15% completeness, 15% FP) mean you want to lean sli
 
 | Range   | Interpretation                                                    |
 |---------|-------------------------------------------------------------------|
-| 80-95+  | Competitive. You are in contention for winner-takes-all.          |
+| 80-95+  | Competitive. You are in contention for the top paid ranks.        |
 | 60-80   | Solid baseline. Targeted parameter tuning can push you higher.    |
 | 40-60   | Something is suboptimal. Check tool parameters and Docker image.  |
 | Below 40| Likely a configuration error. See Common Mistakes below.          |

--- a/neurons/README.md
+++ b/neurons/README.md
@@ -115,7 +115,7 @@ A validator uses miners config file and selected hyperparameters to run the vari
    - After scoring window closes, fetch peer scores for miners not personally covered
    - Track personal and backfilled scores with EMA (exponential moving average)
    - Record round participation once with the complete personal + backfilled hotkey set
-   - Compute warmup split or winner-takes-all weights from EMA
+   - Compute warmup split or winner-heavy pruning dust weights from EMA
    - Submit weight history to the platform for aggregation/dashboarding
    - Submit weights to Bittensor blockchain only when the validator hotkey is registered
 
@@ -203,7 +203,7 @@ python -m neurons.validator
 │                          VALIDATOR                               │
 │  5. Re-run each miner's tool config locally                      │
 │  6. Score with hap.py against merged truth                       │
-│  7. Update EMA scores, winner-takes-all weights                  │
+│  7. Update EMA scores, winner-heavy pruning dust weights         │
 │  8. Submit weights to blockchain                                 │
 └──────────────────────────┬──────────────────────────────────────┘
                            ▼
@@ -218,9 +218,9 @@ python -m neurons.validator
 
 Weights are assigned in two phases:
 
-**Warmup** (before any miner has scored in ≥10 rounds): reward is split among the top 3 active miners with positive EMA — 50% to 1st, 30% to 2nd, 20% to 3rd, renormalized if fewer than three qualify. Scores within 0.5% of each other are tiebroken by earliest submission time.
+**Warmup** (before any miner has scored in ≥10 rounds): the non-burn miner budget is split among the top 3 active miners with positive EMA — 50% to 1st, 30% to 2nd, 20% to 3rd, renormalized if fewer than three qualify. Scores within 0.5% of each other are tiebroken by earliest submission time.
 
-**Normal** (once any miner reaches eligibility): the single top-performing eligible miner by EMA receives 100% of the weight. Eligibility requires scoring in at least 10 of the last 20 rounds; ineligible miners receive 0 weight in normal mode. Absent miners' EMA decays each round they miss (×0.95). Tiebreaker: earliest submission timestamp (applied only at floating-point tolerance).
+**Normal** (once any miner reaches eligibility): validators burn 87%, give the top eligible miner 10%, and split the remaining 3% across eligible ranks #2 through #10 using ranked pruning dust. Eligibility requires scoring in at least 10 of the last 20 rounds; ineligible miners receive 0 weight in normal mode. Absent miners' EMA decays each round they miss (×0.95). Tiebreaker: earliest submission timestamp (applied only at floating-point tolerance).
 
 ## Requirements
 

--- a/neurons/__init__.py
+++ b/neurons/__init__.py
@@ -7,7 +7,7 @@ Miner and Validator are meant to be run as scripts via:
 They are not imported as library components.
 """
 
-MINOS_SPEC_VERSION = "0.1.1"
+MINOS_SPEC_VERSION = "0.1.2"
 SPEC_STRING = MINOS_SPEC_VERSION.split(".")
 SPEC_VERSION_MAJOR = 100*int(SPEC_STRING[0])
 SPEC_VERSION_MINOR = 10*int(SPEC_STRING[1])

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -1180,38 +1180,100 @@ class Validator:
                 bt.logging.info("No miners scored — skipping weight assignment")
                 return
 
-            weights = self.score_tracker.get_winner_takes_all_weights(
-                tracked_miners, submission_times
+            # Network reward params are authoritative. If the platform cannot
+            # provide a complete policy, fail closed instead of silently using
+            # stale local defaults.
+            network_cfg = await self.platform_client.get_network_config()
+            required_policy_fields = {
+                "burn_rate",
+                "burn_uid",
+                "winner_weight",
+                "dust_top_n",
+                "dust_decay",
+            }
+            if not network_cfg:
+                bt.logging.error(
+                    "Network reward config unavailable — skipping weight "
+                    "submission to avoid stale reward policy"
+                )
+                return
+            if not isinstance(network_cfg, dict):
+                bt.logging.error(
+                    f"Network reward config has invalid shape: {network_cfg!r} — "
+                    "skipping weight submission"
+                )
+                return
+            missing_policy_fields = sorted(required_policy_fields - set(network_cfg))
+            if missing_policy_fields:
+                bt.logging.error(
+                    "Network reward config missing required fields "
+                    f"{missing_policy_fields} — skipping weight submission"
+                )
+                return
+            try:
+                burn_rate = float(network_cfg["burn_rate"])
+                burn_uid = int(network_cfg["burn_uid"])
+                winner_weight = float(network_cfg["winner_weight"])
+                dust_top_n = int(network_cfg["dust_top_n"])
+                dust_decay = float(network_cfg["dust_decay"])
+            except (TypeError, ValueError) as exc:
+                bt.logging.error(
+                    f"Invalid network reward config {network_cfg}: {exc} — "
+                    "skipping weight submission"
+                )
+                return
+            miner_budget = 1.0 - burn_rate
+            if not 0.0 <= burn_rate <= 1.0:
+                bt.logging.error(f"Invalid burn_rate={burn_rate} — skipping weight submission")
+                return
+            if burn_uid < 0:
+                bt.logging.error(f"Invalid burn_uid={burn_uid} — skipping weight submission")
+                return
+            if not 0.0 <= winner_weight <= miner_budget:
+                bt.logging.error(
+                    f"Invalid winner_weight={winner_weight} for "
+                    f"miner_budget={miner_budget} — skipping weight submission"
+                )
+                return
+            if dust_top_n < 1:
+                bt.logging.error(f"Invalid dust_top_n={dust_top_n} — skipping weight submission")
+                return
+            if dust_decay < 0.0:
+                bt.logging.error(f"Invalid dust_decay={dust_decay} — skipping weight submission")
+                return
+
+            weights = self.score_tracker.get_winner_heavy_pruning_dust_weights(
+                tracked_miners,
+                submission_times,
+                burn_rate=burn_rate,
+                winner_weight=winner_weight,
+                dust_top_n=dust_top_n,
+                dust_decay=dust_decay,
             )
 
-            # Apply burn split: scale miners to (1 - burn_rate), give burn the
-            # rest. Falls through to 100% burn if no miner has weight.
-            # burn_rate from platform if available, else BURN_RATE env.
-            network_cfg = await self.platform_client.get_network_config()
-            if network_cfg and "burn_rate" in network_cfg:
-                burn_rate = float(network_cfg["burn_rate"])
-                burn_uid = int(network_cfg.get("burn_uid", 0))
-            else:
-                burn_rate = float(GENOMICS_CONFIG.get("burn_rate", 0.9))
-                burn_uid = 0
-            burn_rate = max(0.0, min(1.0, burn_rate))
             burn_hotkey = ""
-            if burn_rate > 0 and len(self.metagraph.hotkeys) > burn_uid:
+            burn_weight = max(0.0, 1.0 - sum(weights.values()))
+            if burn_weight > 1e-12 and len(self.metagraph.hotkeys) <= burn_uid:
+                bt.logging.error(
+                    f"Burn UID {burn_uid} unavailable in metagraph — skipping "
+                    "weight submission to avoid renormalizing miner weights"
+                )
+                return
+
+            if len(self.metagraph.hotkeys) > burn_uid:
                 burn_hotkey = self.metagraph.hotkeys[burn_uid]
-                if sum(weights.values()) > 0:
-                    scale = 1.0 - burn_rate
-                    for hk in list(weights.keys()):
-                        weights[hk] *= scale
-                    weights[burn_hotkey] = burn_rate
-                else:
-                    weights[burn_hotkey] = 1.0
-                bt.logging.info(f"burn {burn_rate * 100:.0f}% -> uid {burn_uid} ({burn_hotkey[:12]}...)")
+                weights[burn_hotkey] = weights.get(burn_hotkey, 0.0) + burn_weight
+                bt.logging.info(
+                    f"burn {burn_weight * 100:.2f}% -> uid {burn_uid} "
+                    f"({burn_hotkey[:12]}...), winner={winner_weight:.4f}, "
+                    f"dust_top_n={dust_top_n}, dust_decay={dust_decay:.2f}"
+                )
 
             # Log weight distribution (mode-aware)
             stats = self.score_tracker.get_stats()
             recipients = [hk for hk, w in weights.items() if w > 0]
             is_warmup = stats['eligible_count'] == 0
-            mode_label = "warmup split" if is_warmup else "winner-takes-all"
+            mode_label = "warmup split" if is_warmup else "winner-heavy + pruning dust"
             print(f"\n   Weight distribution ({mode_label}):", flush=True)
             print(f"   Eligible: {stats['eligible_count']}/{len(tracked_miners)} miners "
                   f"(need {stats['min_rounds_required']} rounds)", flush=True)
@@ -1219,7 +1281,7 @@ class Validator:
                 for r_hk in recipients:
                     r_w = weights[r_hk]
                     r_ema = self.score_tracker.ema_scores.get(r_hk, 0)
-                    print(f"   {r_hk[:16]}... EMA={r_ema:.4f} weight={r_w:.2f}", flush=True)
+                    print(f"   {r_hk[:16]}... EMA={r_ema:.4f} weight={r_w:.6f}", flush=True)
             else:
                 print(f"   No recipients — weights submission skipped (fail-closed)", flush=True)
 
@@ -1274,8 +1336,8 @@ class Validator:
         """Set weights on the blockchain.
 
         Args:
-            weights_by_hotkey: Dict of {hotkey: weight} from ScoreTracker.
-                              If None, computes weights from current EMA scores.
+            weights_by_hotkey: Dict of {hotkey: weight} from the validator
+                              weight policy. Required.
             hotkey_to_uid: Dict of {hotkey: uid} mapping.
                           If None, builds from metagraph.
             retry_count: Number of retry attempts.
@@ -1296,9 +1358,12 @@ class Validator:
             else:
                 miner_hotkeys = list(hotkey_to_uid.keys())
 
-            # Compute weights if not provided
             if weights_by_hotkey is None:
-                weights_by_hotkey = self.score_tracker.get_winner_takes_all_weights(miner_hotkeys)
+                bt.logging.error(
+                    "No explicit weights supplied to set_weights — skipping "
+                    "rather than computing a legacy policy"
+                )
+                return False
 
             if not miner_hotkeys:
                 bt.logging.warning("No miners found to set weights on")
@@ -1312,11 +1377,10 @@ class Validator:
                 miner_uids.append(uid)
                 miner_weights.append(weights_by_hotkey.get(hk, 0.0))
 
-            # Re-normalize to sum to 1 (safety check)
+            # Validate exact policy vector. Do not silently renormalize a
+            # partial vector because that changes burn/winner/dust ratios.
             total = sum(miner_weights)
-            if total > 0:
-                miner_weights = [w / total for w in miner_weights]
-            else:
+            if total <= 0:
                 # Fail closed — never silently distribute equal weights.
                 # Zero-sum weights indicate a scoring failure or no eligible miners
                 # with positive EMA. Submitting equal weights would leak emissions.
@@ -1326,6 +1390,13 @@ class Validator:
                     "This may indicate a scoring failure or all miners having zero EMA."
                 )
                 return False
+            if abs(total - 1.0) > 1e-6:
+                bt.logging.error(
+                    f"WEIGHT SAFETY: explicit weights sum to {total:.8f}, "
+                    "expected 1.0 — skipping rather than renormalizing"
+                )
+                return False
+            miner_weights = [w / total for w in miner_weights]
 
             # CRITICAL: Use numpy arrays, NOT torch tensors!
             uids_array = np.array(miner_uids, dtype=np.int64)

--- a/tests/test_weight_tracking.py
+++ b/tests/test_weight_tracking.py
@@ -7,6 +7,10 @@ from utils.weight_tracking import (
     PARTICIPATION_WINDOW,
     WARMUP_WEIGHTS,
     SCORE_EPSILON,
+    DEFAULT_BURN_RATE,
+    DEFAULT_WINNER_WEIGHT,
+    DEFAULT_DUST_TOP_N,
+    DEFAULT_DUST_DECAY,
 )
 
 
@@ -47,6 +51,14 @@ def _make_active(tracker: ScoreTracker, hotkey: str, rounds: int = 1,
     for i in range(rounds):
         tracker.update(hotkey, score)
         tracker.record_round(f"active-{hotkey}-{i}", [hotkey])
+
+
+DEFAULT_REWARD_POLICY = {
+    "burn_rate": DEFAULT_BURN_RATE,
+    "winner_weight": DEFAULT_WINNER_WEIGHT,
+    "dust_top_n": DEFAULT_DUST_TOP_N,
+    "dust_decay": DEFAULT_DUST_DECAY,
+}
 
 
 # =========================================================================
@@ -216,147 +228,114 @@ class TestEligibility:
 
 
 # =========================================================================
-# TestWinnerTakesAllNormal
+# TestWinnerHeavyPruningDust
 # =========================================================================
 
-class TestWinnerTakesAllNormal:
-    """Normal mode: at least one eligible miner exists."""
+class TestWinnerHeavyPruningDust:
+    """Production normal mode: winner-heavy with pruning dust for top ranks."""
 
-    def test_single_eligible_miner(self, score_tracker):
-        _make_eligible(score_tracker, "hk_a", score=0.80)
-        weights = score_tracker.get_winner_takes_all_weights(["hk_a"])
-        assert weights["hk_a"] == pytest.approx(1.0)
+    def test_top_ten_distribution(self, score_tracker):
+        scores = {
+            f"hk_{i}": 1.0 - (i * 0.01)
+            for i in range(1, 12)
+        }
+        _make_eligible_group(score_tracker, scores)
 
-    def test_higher_ema_wins(self, score_tracker):
-        _make_eligible_group(score_tracker, {"hk_a": 0.90, "hk_b": 0.70})
-        weights = score_tracker.get_winner_takes_all_weights(["hk_a", "hk_b"])
-        assert weights["hk_a"] == pytest.approx(1.0)
-        assert weights["hk_b"] == pytest.approx(0.0)
-
-    def test_tie_ema_earlier_submission_wins(self, score_tracker):
-        _make_eligible_group(score_tracker, {"hk_a": 0.80, "hk_b": 0.80})
-        times = {"hk_a": 1000.0, "hk_b": 999.0}  # hk_b submitted earlier
-        weights = score_tracker.get_winner_takes_all_weights(
-            ["hk_a", "hk_b"], submission_times=times
+        hotkeys = list(scores.keys())
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            hotkeys, **DEFAULT_REWARD_POLICY
         )
-        assert weights["hk_b"] == pytest.approx(1.0)
-        assert weights["hk_a"] == pytest.approx(0.0)
+
+        assert weights["hk_1"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
+        assert weights["hk_11"] == pytest.approx(0.0)
+
+        dust_pool = 1.0 - DEFAULT_BURN_RATE - DEFAULT_WINNER_WEIGHT
+        dust_raw = [DEFAULT_DUST_DECAY ** i for i in range(DEFAULT_DUST_TOP_N - 1)]
+        dust_total = sum(dust_raw)
+        for rank in range(2, 11):
+            expected = dust_pool * dust_raw[rank - 2] / dust_total
+            assert weights[f"hk_{rank}"] == pytest.approx(expected)
+
+        assert sum(weights.values()) == pytest.approx(1.0 - DEFAULT_BURN_RATE)
+
+    def test_default_top_ten_dust_survives_u16_emit_rounding(self, score_tracker):
+        scores = {
+            f"hk_{i}": 1.0 - (i * 0.01)
+            for i in range(1, 11)
+        }
+        _make_eligible_group(score_tracker, scores)
+
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            list(scores.keys()), **DEFAULT_REWARD_POLICY
+        )
+        burn_weight = 1.0 - sum(weights.values())
+        max_weight = max(burn_weight, max(weights.values()))
+
+        for rank in range(2, 11):
+            encoded = round(weights[f"hk_{rank}"] / max_weight * 65535)
+            assert encoded > 0
+
+    def test_fewer_than_ten_eligible_renormalizes_dust(self, score_tracker):
+        _make_eligible_group(
+            score_tracker,
+            {"hk_a": 0.90, "hk_b": 0.80, "hk_c": 0.70},
+        )
+
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a", "hk_b", "hk_c"], **DEFAULT_REWARD_POLICY
+        )
+
+        dust_pool = 1.0 - DEFAULT_BURN_RATE - DEFAULT_WINNER_WEIGHT
+        dust_total = 1.0 + DEFAULT_DUST_DECAY
+        assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
+        assert weights["hk_b"] == pytest.approx(dust_pool / dust_total)
+        assert weights["hk_c"] == pytest.approx(dust_pool * DEFAULT_DUST_DECAY / dust_total)
+        assert sum(weights.values()) == pytest.approx(1.0 - DEFAULT_BURN_RATE)
+
+    def test_single_eligible_keeps_winner_weight_only(self, score_tracker):
+        _make_eligible(score_tracker, "hk_a", score=0.90)
+
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a"], **DEFAULT_REWARD_POLICY
+        )
+
+        assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
+        assert sum(weights.values()) == pytest.approx(DEFAULT_WINNER_WEIGHT)
+
+    def test_ineligible_high_ema_gets_zero(self, score_tracker):
+        _make_eligible(score_tracker, "hk_a", score=0.80)
+        _make_active(score_tracker, "hk_b", rounds=1, score=0.99)
+
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a", "hk_b"], **DEFAULT_REWARD_POLICY
+        )
+
+        assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
+        assert weights["hk_b"] == pytest.approx(0.0)
 
     def test_all_eligible_zero_ema_returns_all_zero(self, score_tracker):
-        """Fail-closed: if every eligible miner has EMA=0, all weights are 0."""
-        # Manually make eligible without actual scoring (force 0 EMA)
-        for i in range(10):
+        for i in range(score_tracker.min_rounds):
             score_tracker.record_round(f"r{i}", ["hk_a", "hk_b"])
-        # Participation is now 10, but no update() was ever called → EMA=0
-        weights = score_tracker.get_winner_takes_all_weights(["hk_a", "hk_b"])
+
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a", "hk_b"], **DEFAULT_REWARD_POLICY
+        )
+
         assert weights["hk_a"] == pytest.approx(0.0)
         assert weights["hk_b"] == pytest.approx(0.0)
 
-    def test_winner_gets_one_others_zero(self, score_tracker):
-        _make_eligible_group(
-            score_tracker, {"hk_a": 0.90, "hk_b": 0.70, "hk_c": 0.50}
-        )
-        weights = score_tracker.get_winner_takes_all_weights(
-            ["hk_a", "hk_b", "hk_c"]
-        )
-        assert weights["hk_a"] == pytest.approx(1.0)
-        assert weights["hk_b"] == pytest.approx(0.0)
-        assert weights["hk_c"] == pytest.approx(0.0)
-
-    def test_non_eligible_miners_always_zero(self, score_tracker):
-        _make_eligible(score_tracker, "hk_a", score=0.90)
-        # hk_b has only 1 round
-        _make_active(score_tracker, "hk_b", rounds=1, score=0.99)
-        weights = score_tracker.get_winner_takes_all_weights(["hk_a", "hk_b"])
-        assert weights["hk_a"] == pytest.approx(1.0)
-        assert weights["hk_b"] == pytest.approx(0.0)
-
-    def test_empty_miner_list(self, score_tracker):
-        weights = score_tracker.get_winner_takes_all_weights([])
-        assert weights == {}
-
-    def test_no_submission_times_still_works(self, score_tracker):
-        _make_eligible(score_tracker, "hk_a", score=0.80)
-        weights = score_tracker.get_winner_takes_all_weights(
-            ["hk_a"], submission_times=None
-        )
-        assert weights["hk_a"] == pytest.approx(1.0)
-
-
-# =========================================================================
-# TestWinnerTakesAllWarmup
-# =========================================================================
-
-class TestWinnerTakesAllWarmup:
-    """Warmup mode: no miner has reached eligibility yet."""
-
-    def test_one_active_gets_full_weight(self, score_tracker):
-        """1 active miner → renormalized [0.5] = [1.0]."""
-        _make_active(score_tracker, "hk_a", rounds=1, score=0.80)
-        weights = score_tracker.get_winner_takes_all_weights(["hk_a"])
-        assert weights["hk_a"] == pytest.approx(1.0)
-
-    def test_two_active_renormalized_split(self, score_tracker):
-        """2 active miners → renormalized [0.5, 0.3] = [0.625, 0.375]."""
+    def test_warmup_scaled_to_non_burn_budget(self, score_tracker):
         _make_active(score_tracker, "hk_a", rounds=1, score=0.90)
         _make_active(score_tracker, "hk_b", rounds=1, score=0.70)
-        weights = score_tracker.get_winner_takes_all_weights(["hk_a", "hk_b"])
-        assert weights["hk_a"] == pytest.approx(0.5 / 0.8)  # 0.625
-        assert weights["hk_b"] == pytest.approx(0.3 / 0.8)  # 0.375
 
-    def test_three_active_exact_warmup_weights(self, score_tracker):
-        """3 active miners → 50/30/20 split."""
-        _make_active(score_tracker, "hk_a", rounds=1, score=0.90)
-        _make_active(score_tracker, "hk_b", rounds=1, score=0.70)
-        _make_active(score_tracker, "hk_c", rounds=1, score=0.50)
-        weights = score_tracker.get_winner_takes_all_weights(
-            ["hk_a", "hk_b", "hk_c"]
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a", "hk_b"], **DEFAULT_REWARD_POLICY
         )
-        assert weights["hk_a"] == pytest.approx(0.50)
-        assert weights["hk_b"] == pytest.approx(0.30)
-        assert weights["hk_c"] == pytest.approx(0.20)
 
-    def test_no_active_miners_all_zero(self, score_tracker):
-        """No one has participated → all weights zero."""
-        weights = score_tracker.get_winner_takes_all_weights(
-            ["hk_a", "hk_b"]
-        )
-        assert weights["hk_a"] == pytest.approx(0.0)
-        assert weights["hk_b"] == pytest.approx(0.0)
-
-    def test_all_active_zero_ema_equal_split(self, score_tracker):
-        """All active miners have zero EMA → equal split among active."""
-        # Make active via record_round but never call update()
-        score_tracker.record_round("r0", ["hk_a", "hk_b"])
-        weights = score_tracker.get_winner_takes_all_weights(
-            ["hk_a", "hk_b"]
-        )
-        assert weights["hk_a"] == pytest.approx(0.5)
-        assert weights["hk_b"] == pytest.approx(0.5)
-
-    def test_tiebreak_by_submission_time_in_warmup(self, score_tracker):
-        """Within SCORE_EPSILON, earlier submission wins higher position."""
-        # Both get EMA within epsilon of each other
-        _make_active(score_tracker, "hk_a", rounds=1, score=0.80)
-        _make_active(score_tracker, "hk_b", rounds=1, score=0.80)
-        times = {"hk_a": 500.0, "hk_b": 100.0}  # hk_b is earlier
-        weights = score_tracker.get_winner_takes_all_weights(
-            ["hk_a", "hk_b"], submission_times=times
-        )
-        # hk_b should rank first (earlier time), hk_a second
-        assert weights["hk_b"] > weights["hk_a"]
-        # Renormalized [0.5, 0.3] → 0.625, 0.375
-        assert weights["hk_b"] == pytest.approx(0.5 / 0.8)
-        assert weights["hk_a"] == pytest.approx(0.3 / 0.8)
-
-    def test_inactive_miners_get_zero_in_warmup(self, score_tracker):
-        """Miners with 0 participation get 0 even in warmup."""
-        _make_active(score_tracker, "hk_a", rounds=1, score=0.80)
-        weights = score_tracker.get_winner_takes_all_weights(
-            ["hk_a", "hk_inactive"]
-        )
-        assert weights["hk_a"] == pytest.approx(1.0)
-        assert weights["hk_inactive"] == pytest.approx(0.0)
+        miner_budget = 1.0 - DEFAULT_BURN_RATE
+        assert weights["hk_a"] == pytest.approx(miner_budget * 0.5 / 0.8)
+        assert weights["hk_b"] == pytest.approx(miner_budget * 0.3 / 0.8)
+        assert sum(weights.values()) == pytest.approx(miner_budget)
 
 
 # =========================================================================
@@ -424,7 +403,9 @@ class TestRankingsAndHistory:
         tracker = score_tracker_low_threshold
         _make_eligible_group(tracker, {"hk_a": 0.90, "hk_b": 0.70})
 
-        weights = tracker.get_winner_takes_all_weights(["hk_a", "hk_b"])
+        weights = tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a", "hk_b"], **DEFAULT_REWARD_POLICY
+        )
         entries = tracker.build_weight_history(
             round_id="r_final",
             validator_hotkey="val_hk",
@@ -440,11 +421,13 @@ class TestRankingsAndHistory:
 
         # Winner entry
         winner = [e for e in entries if e["miner_hotkey"] == "hk_a"][0]
-        assert winner["weight"] == pytest.approx(1.0)
+        assert winner["weight"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
         assert winner["eligible"] is True
         assert winner["rank"] == 1
 
         loser = [e for e in entries if e["miner_hotkey"] == "hk_b"][0]
-        assert loser["weight"] == pytest.approx(0.0)
+        assert loser["weight"] == pytest.approx(
+            1.0 - DEFAULT_BURN_RATE - DEFAULT_WINNER_WEIGHT
+        )
         assert loser["eligible"] is True
         assert loser["rank"] == 2

--- a/utils/README.md
+++ b/utils/README.md
@@ -53,7 +53,7 @@ score = AdvancedScorer.compute_advanced_score(results)
 
 ### 2. Weight Tracking (weight_tracking.py)
 
-**Purpose:** Tracks miner performance over time with EMA smoothing and winner-takes-all weights.
+**Purpose:** Tracks miner performance over time with EMA smoothing and winner-heavy pruning dust weights.
 
 **Main Class:** `ScoreTracker`
 
@@ -65,15 +65,21 @@ tracker = ScoreTracker(alpha=0.1)
 # Update a miner's score
 tracker.update(hotkey="5xxx...", raw_score=0.92)
 
-# Get normalized weights for blockchain
-weights = tracker.get_winner_takes_all_weights(miner_hotkeys=["5xxx...", "5yyy..."])
+# Get absolute miner weights before the validator adds burn
+weights = tracker.get_winner_heavy_pruning_dust_weights(
+    miner_hotkeys=["5xxx...", "5yyy..."],
+    burn_rate=0.87,
+    winner_weight=0.10,
+    dust_top_n=10,
+    dust_decay=0.8,
+)
 # Returns: {hotkey: weight} mapping
 ```
 
 **Algorithm:**
 
 1. **EMA Smoothing:**
-2. **Winner-Takes-All:** 
+2. **Winner-Heavy Pruning Dust:**
 3. **Participation Gating:** 
 4. **Normalization:** 
 
@@ -194,7 +200,7 @@ await client.submit_score(
    ValidatorPlatformClient.get_backfill_scores()
    ScoreTracker.record_round(personal + backfilled hotkeys)
    |
-8. ScoreTracker.get_winner_takes_all_weights()
+8. ScoreTracker.get_winner_heavy_pruning_dust_weights()
    ValidatorPlatformClient.submit_weight_history()
    set_weights() on Bittensor if validator is registered
 ```

--- a/utils/platform_client.py
+++ b/utils/platform_client.py
@@ -135,8 +135,10 @@ class PlatformClient:
             return False
 
     async def get_network_config(self) -> Optional[Dict[str, Any]]:
-        """Fetch network reward params (burn_rate, burn_uid). Returns None on
-        any error so the caller can fall back to env defaults."""
+        """Fetch authoritative network reward params.
+
+        Returns None on any error; validators must treat that as fail-closed.
+        """
         try:
             async with self._get_client() as client:
                 response = await client.get("/scoring/network-config")
@@ -787,7 +789,7 @@ class ValidatorPlatformClient(PlatformClient):
     ) -> Dict[str, Any]:
         """Submit weight history (EMA scores, ranks, weights) for a round.
 
-        Called after computing winner-takes-all weights so the platform
+        Called after computing validator weights so the platform
         can display historical scoring data on the dashboard.
 
         Args:

--- a/utils/weight_tracking.py
+++ b/utils/weight_tracking.py
@@ -6,8 +6,9 @@ Weight distribution has two phases:
 
 - Warmup (before any miner reaches min_rounds): positional reward split
   50/30/20 among the top 3 scoring active miners (>= 1 round) by EMA.
-- Normal (once any miner is eligible): winner-takes-all — the single
-  top-performing eligible miner receives 100% of the weight.
+- Normal (once any miner is eligible): winner-heavy — the single
+  top-performing eligible miner receives the main reward, with pruning dust
+  distributed to the next ranked eligible miners.
 
 Eligibility requires scoring in at least `min_rounds` of the recent window.
 Tiebreaker: earliest submission timestamp in the most recent round.
@@ -40,6 +41,15 @@ WARMUP_WEIGHTS = [0.50, 0.30, 0.20]
 
 # Scores within this epsilon are treated as tied; tiebreak by submission time.
 SCORE_EPSILON = 0.005
+EMA_TOLERANCE = 1e-9
+
+# Normal phase defaults. These are absolute validator-vector weights before
+# Bittensor's u16 encoding: burn gets 0.87, rank #1 gets 0.10, and ranks
+# #2-#10 split the remaining 0.03 by geometric decay.
+DEFAULT_BURN_RATE = 0.87
+DEFAULT_WINNER_WEIGHT = 0.10
+DEFAULT_DUST_TOP_N = 10
+DEFAULT_DUST_DECAY = 0.80
 
 
 class ScoreTracker:
@@ -208,138 +218,132 @@ class ScoreTracker:
         """Check if a miner meets the minimum participation requirement."""
         return self.get_participation_count(hotkey) >= self.min_rounds
 
-    def get_winner_takes_all_weights(
+    def _sort_by_ema(
+        self,
+        hotkeys: List[str],
+        submission_times: Optional[Dict[str, float]] = None,
+        tolerance: float = EMA_TOLERANCE,
+    ) -> List[str]:
+        """Sort hotkeys by EMA descending, tiebreaking by earliest submission."""
+        def _cmp(hk_a, hk_b):
+            sa = self.ema_scores.get(hk_a, 0.0)
+            sb = self.ema_scores.get(hk_b, 0.0)
+            ta = submission_times.get(hk_a, float("inf")) if submission_times else float("inf")
+            tb = submission_times.get(hk_b, float("inf")) if submission_times else float("inf")
+            if abs(sa - sb) <= tolerance:
+                return -1 if ta < tb else (1 if ta > tb else 0)
+            return -1 if sa > sb else 1
+
+        return sorted(hotkeys, key=functools.cmp_to_key(_cmp))
+
+    def get_winner_heavy_pruning_dust_weights(
         self,
         miner_hotkeys: List[str],
         submission_times: Optional[Dict[str, float]] = None,
+        *,
+        burn_rate: float,
+        winner_weight: float,
+        dust_top_n: int,
+        dust_decay: float,
     ) -> Dict[str, float]:
         """
-        Compute weight distribution.
+        Compute absolute validator-vector miner weights.
 
-        Two modes:
-        - **Warmup** (no miner has min_rounds yet): positional split
-          (50/30/20) among top active miners by EMA score.
-          Inactive miners (0 rounds) get zero weight.
-        - **Normal**: winner-takes-all — single top eligible miner gets 100%.
-
-        Tiebreak in both modes: earliest submission timestamp.
-
-        Args:
-            miner_hotkeys: List of all miner hotkeys to consider.
-            submission_times: Optional dict of {hotkey: submitted_at_epoch}
-                              for tiebreaking. Typically from the most recent
-                              round's submission timestamps.
-
-        Returns:
-            Dict of {hotkey: weight} for all miners in miner_hotkeys.
+        Warmup keeps the existing 50/30/20 active-miner split, scaled to the
+        non-burn budget. Normal mode keeps rank #1 at ``winner_weight`` and
+        splits the remaining non-burn budget across ranks #2..dust_top_n.
+        Unused dust is intentionally left unallocated so the caller can add it
+        to burn.
         """
         weights = {hk: 0.0 for hk in miner_hotkeys}
+        if not miner_hotkeys:
+            return weights
 
-        # Find eligible miners
+        burn_rate = float(burn_rate)
+        winner_weight = float(winner_weight)
+        dust_top_n = int(dust_top_n)
+        dust_decay = float(dust_decay)
+        miner_budget = 1.0 - burn_rate
+        if not 0.0 <= burn_rate <= 1.0:
+            raise ValueError(f"burn_rate must be between 0 and 1, got {burn_rate}")
+        if not 0.0 <= winner_weight <= miner_budget:
+            raise ValueError(
+                f"winner_weight must be between 0 and miner budget "
+                f"{miner_budget}, got {winner_weight}"
+            )
+        if dust_top_n < 1:
+            raise ValueError(f"dust_top_n must be >= 1, got {dust_top_n}")
+        if dust_decay < 0.0:
+            raise ValueError(f"dust_decay must be >= 0, got {dust_decay}")
+
         eligible = [hk for hk in miner_hotkeys if self.is_eligible(hk)]
 
         if not eligible:
-            # Warmup phase: no miner has hit the eligibility threshold yet.
-            # Split reward equally among top WARMUP_TOP_N scoring active miners
-            # (those who have participated in >= 1 round).
-            active = [hk for hk in miner_hotkeys
-                      if self.get_participation_count(hk) > 0]
-
+            active = [
+                hk for hk in miner_hotkeys
+                if self.get_participation_count(hk) > 0
+            ]
             if not active:
-                logger.info("No active miners yet — all weights zero")
+                logger.info("No active miners yet — all miner weights zero")
                 return weights
 
-            # Sort by EMA score (desc); scores within SCORE_EPSILON are treated
-            # as tied and ranked by earliest submission time instead.
-            def _cmp(hk_a, hk_b):
-                sa = self.ema_scores.get(hk_a, 0.0)
-                sb = self.ema_scores.get(hk_b, 0.0)
-                ta = submission_times.get(hk_a, float("inf")) if submission_times else float("inf")
-                tb = submission_times.get(hk_b, float("inf")) if submission_times else float("inf")
-                if abs(sa - sb) <= SCORE_EPSILON:
-                    # Within epsilon — earlier submission ranks higher
-                    return -1 if ta < tb else (1 if ta > tb else 0)
-                # Clear score difference — higher EMA ranks higher
-                return -1 if sa > sb else 1
-
-            sorted_active = sorted(active, key=functools.cmp_to_key(_cmp))
-
-            # Positionally split among top N active miners with EMA > 0
+            sorted_active = self._sort_by_ema(
+                active, submission_times, tolerance=SCORE_EPSILON
+            )
             top_n = [
                 hk for hk in sorted_active[:WARMUP_TOP_N]
                 if self.ema_scores.get(hk, 0.0) > 0
             ]
-
             if top_n:
-                # Positional split: renormalize WARMUP_WEIGHTS to however many
-                # miners actually scored > 0 (e.g. if only 2, split 50/30 → ~0.625/0.375)
                 raw_w = WARMUP_WEIGHTS[:len(top_n)]
                 total_w = sum(raw_w)
-                positional_w = [w / total_w for w in raw_w]
-                for hk, w in zip(top_n, positional_w):
-                    weights[hk] = w
-                top_scores = [
-                    (hk[:16], self.ema_scores.get(hk, 0.0), w)
-                    for hk, w in zip(top_n, positional_w)
-                ]
+                for hk, raw in zip(top_n, raw_w):
+                    weights[hk] = miner_budget * raw / total_w
                 logger.info(
-                    f"Warmup: top-{len(top_n)} positional split "
-                    f"(active: {len(active)}/{len(miner_hotkeys)}, "
-                    f"need {self.min_rounds} rounds for EMA eligibility): "
-                    + ", ".join(f"{hk}...=ema:{s:.4f} w:{w:.2f}" for hk, s, w in top_scores)
+                    f"Warmup: top-{len(top_n)} split over miner budget "
+                    f"{miner_budget:.4f}"
                 )
             else:
-                # All active miners have zero EMA — split among active only
-                equal_w = 1.0 / len(active)
+                equal_w = miner_budget / len(active) if active else 0.0
                 for hk in active:
                     weights[hk] = equal_w
                 logger.info(
                     f"Warmup: all active miners scored zero, "
-                    f"equal weights to {len(active)} active miners"
+                    f"equal miner-budget split to {len(active)} active miners"
                 )
             return weights
 
-        # Find winner: highest EMA, tiebreak by earliest submission
-        # Use tolerance for float comparison to avoid precision issues
-        EMA_TOLERANCE = 1e-9
-        best_hotkey = None
-        best_ema = -1.0
-        best_time = float("inf")
-
-        for hk in eligible:
-            ema = self.ema_scores.get(hk, 0.0)
-            sub_time = (
-                submission_times.get(hk, float("inf"))
-                if submission_times
-                else float("inf")
+        ranked = [
+            hk for hk in self._sort_by_ema(
+                eligible, submission_times, tolerance=EMA_TOLERANCE
             )
+            if self.ema_scores.get(hk, 0.0) > 0
+        ]
 
-            if ema > best_ema + EMA_TOLERANCE:
-                # Strictly better EMA — new winner
-                best_ema = ema
-                best_hotkey = hk
-                best_time = sub_time
-            elif abs(ema - best_ema) <= EMA_TOLERANCE and sub_time < best_time:
-                # EMA effectively tied — tiebreak by earliest submission
-                best_ema = ema
-                best_hotkey = hk
-                best_time = sub_time
-
-        if best_hotkey is not None and best_ema > 0:
-            weights[best_hotkey] = 1.0
-            logger.info(
-                f"Winner: {best_hotkey[:16]}... EMA={best_ema:.4f} "
-                f"(eligible: {len(eligible)}/{len(miner_hotkeys)})"
-            )
-        else:
-            # All eligible miners have zero EMA — return all-zero weights (fail closed).
-            # The caller (set_weights) will detect the zero total and skip submission
-            # rather than silently distributing equal emissions.
+        if not ranked:
             logger.warning(
                 f"All {len(eligible)} eligible miners have zero EMA — "
-                f"returning zero weights (no-op). Validator will skip weight submission."
+                f"returning zero miner weights (no-op)."
             )
+            return weights
 
+        winner = ranked[0]
+        weights[winner] = winner_weight
+
+        dust_pool = max(0.0, miner_budget - winner_weight)
+        dust_recipients = ranked[1:dust_top_n]
+        if dust_pool > 0 and dust_recipients:
+            dust_raw = [dust_decay ** i for i in range(len(dust_recipients))]
+            dust_total = sum(dust_raw)
+            if dust_total > 0:
+                for hk, raw in zip(dust_recipients, dust_raw):
+                    weights[hk] = dust_pool * raw / dust_total
+
+        logger.info(
+            f"Winner-heavy weights: winner={winner[:16]}... "
+            f"winner_weight={winner_weight:.4f}, "
+            f"dust_pool={dust_pool:.4f}, dust_recipients={len(dust_recipients)}"
+        )
         return weights
 
     def get_rankings(self, miner_hotkeys: List[str]) -> Dict[str, Optional[int]]:
@@ -381,7 +385,7 @@ class ScoreTracker:
             round_id: The round these weights correspond to.
             validator_hotkey: The validator's hotkey.
             miner_hotkeys: All miner hotkeys.
-            weights: The weight dict from get_winner_takes_all_weights().
+            weights: The weight dict from the active validator weight policy.
 
         Returns:
             List of entry dicts ready for the API.


### PR DESCRIPTION
Implements the new miner weight policy for deregistration resistance:

- Bumps Minos spec version from `0.1.1` to `0.1.2`
- Replace winner-takes-all only weight assignment with winner-heavy pruning dust
- `87%` burn instead of `90%`, `10%` rank #1, `3%` dust across eligible ranks #2-#10
- Updates docs for the new reward distribution

This means:
- Burn UID receives `87%`
- Rank #1 eligible miner receives `10%`
- Eligible ranks #2-#10 split `3%` by geometric decay (`0.8`)
- Ineligible miners and ranks below #10 receive `0` as usual.