### PR TITLE
Improve validator scoring consistency

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,4 +6,4 @@ Miners run GATK, DeepVariant, FreeBayes, or BCFtools to call variants;
 validators score results with hap.py.
 """
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/neurons/__init__.py
+++ b/neurons/__init__.py
@@ -7,7 +7,7 @@ Miner and Validator are meant to be run as scripts via:
 They are not imported as library components.
 """
 
-MINOS_SPEC_VERSION = "0.1.2"
+MINOS_SPEC_VERSION = "0.1.3"
 SPEC_STRING = MINOS_SPEC_VERSION.split(".")
 SPEC_VERSION_MAJOR = 100*int(SPEC_STRING[0])
 SPEC_VERSION_MINOR = 10*int(SPEC_STRING[1])

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -18,6 +18,8 @@ import argparse
 import numpy as np
 import asyncio
 from datetime import datetime, timedelta, timezone
+from typing import Optional
+
 from dotenv import load_dotenv
 
 from neurons import __SPEC_VERSION__
@@ -35,6 +37,10 @@ from utils import (
     HappyScorer,
     ScoreTracker,
     AdvancedScorer,
+)
+from utils.weight_tracking import (
+    CANONICAL_MIN_VALIDATOR_COUNT,
+    CANONICAL_MIN_VALIDATOR_STAKE,
 )
 from utils.scoring import parse_happy_vcf, BCFTOOLS_DOCKER_IMAGE
 from utils.file_utils import compute_sha256
@@ -57,6 +63,8 @@ MAX_WAIT_SECONDS = 14400
 MIN_WAIT_SECONDS = 60
 BITTENSOR_BLOCK_TIME_SECONDS = 12
 MAX_SLEEP_SECONDS = 120
+SCORE_GRACE_SECONDS = int(os.getenv("SCORE_GRACE_SECONDS", "60"))
+SCORE_FINALIZATION_DELAY_SECONDS = int(os.getenv("SCORE_FINALIZATION_DELAY_SECONDS", "5"))
 
 
 def auto_scoring_config():
@@ -877,23 +885,54 @@ class Validator:
         """Backfill gap miners from platform, record participation, then set weights.
 
         Order matters:
-        1. Wait for scoring window to close (commit-then-reveal gate).
+        1. Wait for scoring window + score grace to close (final-score gate).
         2. Fetch backfill scores for miners not personally covered.
         3. Feed each backfill score into ScoreTracker.update().
         4. Call record_round() ONCE with the complete set (personal + backfill).
         5. Set chain weights from the full EMA state.
         """
-        # --- Step 1: Wait for scoring window to close ---
+        # --- Step 1: Wait for scoring window + late-score grace to close ---
+        score_grace_seconds = SCORE_GRACE_SECONDS
+        finalization_delay_seconds = SCORE_FINALIZATION_DELAY_SECONDS
+        if self.platform_client:
+            try:
+                network_cfg = await self.platform_client.get_network_config()
+                if isinstance(network_cfg, dict):
+                    platform_grace = int(
+                        network_cfg.get("score_grace_seconds", score_grace_seconds)
+                    )
+                    platform_delay = int(
+                        network_cfg.get(
+                            "score_finalization_delay_seconds",
+                            finalization_delay_seconds,
+                        )
+                    )
+                    if platform_grace >= 0:
+                        score_grace_seconds = max(score_grace_seconds, platform_grace)
+                    if platform_delay >= 0:
+                        finalization_delay_seconds = max(
+                            finalization_delay_seconds, platform_delay
+                        )
+            except (TypeError, ValueError) as exc:
+                bt.logging.warning(
+                    f"Invalid platform score-grace config ({exc}); "
+                    f"using local defaults grace={score_grace_seconds}s, "
+                    f"finalization={finalization_delay_seconds}s"
+                )
+
         if scoring_deadline is not None:
             now = datetime.now(timezone.utc)
             # Ensure deadline is tz-aware
             if scoring_deadline.tzinfo is None:
                 scoring_deadline = scoring_deadline.replace(tzinfo=timezone.utc)
-            wait_secs = (scoring_deadline - now).total_seconds()
+            final_score_deadline = scoring_deadline + timedelta(
+                seconds=score_grace_seconds + finalization_delay_seconds
+            )
+            wait_secs = (final_score_deadline - now).total_seconds()
             if wait_secs > 0:
                 bt.logging.info(
-                    f"Round {round_id}: waiting {wait_secs:.0f}s for scoring window to close "
-                    f"before fetching backfill scores"
+                    f"Round {round_id}: waiting {wait_secs:.0f}s for score grace "
+                    f"+ finalization delay before fetching backfill/canonical scores"
                 )
                 await asyncio.sleep(wait_secs + 5)
 
@@ -904,10 +943,23 @@ class Validator:
 
         if self.platform_client:
             try:
-                backfill_response = await self.platform_client.get_backfill_scores(
-                    round_id=round_id,
-                    scored_miner_hotkeys=all_scored_hotkeys,
-                )
+                backfill_response = None
+                for attempt in range(6):
+                    try:
+                        backfill_response = await self.platform_client.get_backfill_scores(
+                            round_id=round_id,
+                            scored_miner_hotkeys=all_scored_hotkeys,
+                        )
+                        break
+                    except PlatformClientError as e:
+                        if "Too Early" not in str(e) or attempt >= 5:
+                            raise
+                        wait_seconds = min(15, 5 * (attempt + 1))
+                        bt.logging.info(
+                            f"Round {round_id}: platform final-score gate still closed; "
+                            f"retrying backfill in {wait_seconds}s"
+                        )
+                        await asyncio.sleep(wait_seconds)
 
                 backfill_scores = backfill_response.get("backfill_scores", [])
                 overlap_deltas = backfill_response.get("overlap_deltas", [])
@@ -957,10 +1009,11 @@ class Validator:
                         )
 
             except PlatformClientError as e:
-                bt.logging.warning(
+                bt.logging.error(
                     f"Round {round_id}: backfill fetch failed ({e}). "
-                    f"Proceeding with partial scores — unscored miners will decay normally."
+                    "Skipping weight submission to avoid validator divergence."
                 )
+                return
 
         # --- Step 4: Record round with COMPLETE hotkey set ---
         # This must happen after backfill so decay is only applied to miners
@@ -1216,6 +1269,18 @@ class Validator:
                 winner_weight = float(network_cfg["winner_weight"])
                 dust_top_n = int(network_cfg["dust_top_n"])
                 dust_decay = float(network_cfg["dust_decay"])
+                canonical_min_validator_count = int(
+                    network_cfg.get(
+                        "canonical_min_validator_count",
+                        CANONICAL_MIN_VALIDATOR_COUNT,
+                    )
+                )
+                canonical_min_validator_stake = float(
+                    network_cfg.get(
+                        "canonical_min_validator_stake",
+                        CANONICAL_MIN_VALIDATOR_STAKE,
+                    )
+                )
             except (TypeError, ValueError) as exc:
                 bt.logging.error(
                     f"Invalid network reward config {network_cfg}: {exc} — "
@@ -1241,6 +1306,135 @@ class Validator:
             if dust_decay < 0.0:
                 bt.logging.error(f"Invalid dust_decay={dust_decay} — skipping weight submission")
                 return
+            if canonical_min_validator_count < 1:
+                bt.logging.error(
+                    f"Invalid canonical_min_validator_count={canonical_min_validator_count} "
+                    "— skipping weight submission"
+                )
+                return
+            if canonical_min_validator_stake < 0.0:
+                bt.logging.error(
+                    f"Invalid canonical_min_validator_stake={canonical_min_validator_stake} "
+                    "— skipping weight submission"
+                )
+                return
+
+            # Fetch a round-pinned canonical ranking for close-call winner
+            # selection. If the ranking is unavailable or below quorum, skip
+            # this weight update rather than submitting a local-only winner.
+            # Passing round_id avoids sampling different "latest completed"
+            # rounds during the scheduler's status-promotion interval.
+            canonical_response = await self.platform_client.get_canonical_ranking(
+                round_id=round_id
+            )
+            canonical_ranking = []
+            canonical_parse_failed = False
+            canonical_low_coverage = False
+            if canonical_response is None:
+                # Transport errors and unavailable responses are handled below
+                # by skipping this weight update.
+                pass
+            elif not isinstance(canonical_response, dict):
+                canonical_parse_failed = True
+            else:
+                ranking = canonical_response.get("ranking")
+                if not isinstance(ranking, list):
+                    canonical_parse_failed = True
+                elif not ranking:
+                    canonical_low_coverage = True
+                else:
+                    v_count = canonical_response.get("validator_count", 0)
+                    stake_total = canonical_response.get(
+                        "total_stake_considered", 0.0
+                    )
+                    min_total_stake = (
+                        canonical_min_validator_count
+                        * canonical_min_validator_stake
+                    )
+                    if not isinstance(v_count, int) or v_count < canonical_min_validator_count:
+                        canonical_low_coverage = True
+                    elif not isinstance(stake_total, (int, float)) or stake_total < min_total_stake:
+                        canonical_low_coverage = True
+                    else:
+                        for entry in ranking:
+                            if not isinstance(entry, dict):
+                                canonical_parse_failed = True
+                                break
+                            raw = entry.get("miner_hotkey")
+                            if not isinstance(raw, str):
+                                canonical_parse_failed = True
+                                break
+                            # Trim accidental whitespace without changing
+                            # ss58 casing.
+                            candidate = raw.strip()
+                            if not candidate:
+                                canonical_parse_failed = True
+                                break
+
+                            # Keep a validator-side quorum check for rolling
+                            # upgrades and skip only the affected entry.
+                            entry_count = entry.get("validator_count", 0)
+                            if (
+                                not isinstance(entry_count, int)
+                                or entry_count < canonical_min_validator_count
+                            ):
+                                continue
+                            canonical_ranking.append(candidate)
+
+                        if not canonical_parse_failed and not canonical_ranking:
+                            # No ranked miner met the validator-side quorum.
+                            canonical_low_coverage = True
+
+            if canonical_parse_failed:
+                bt.logging.error(
+                    f"Canonical ranking response malformed "
+                    f"(shape={type(canonical_response).__name__}); "
+                    "skipping weight submission. Check "
+                    "/scoring/canonical-ranking."
+                )
+                return
+            elif canonical_low_coverage:
+                bt.logging.error(
+                    f"Canonical ranking has insufficient coverage for "
+                    f"round {round_id} "
+                    f"(validators={canonical_response.get('validator_count')}, "
+                    f"top_validators="
+                    f"{(canonical_response.get('ranking') or [{}])[0].get('validator_count')}, "
+                    f"stake={canonical_response.get('total_stake_considered')}; "
+                    f"min={canonical_min_validator_count} validators / "
+                    f"{canonical_min_validator_stake} TAO each). Skipping "
+                    "weight submission to avoid validator divergence."
+                )
+                return
+            elif canonical_ranking:
+                bt.logging.info(
+                    f"Canonical ranking top={canonical_ranking[0][:16]}... "
+                    f"({len(canonical_ranking)} candidates) for "
+                    f"round {round_id} "
+                    f"(coverage: {canonical_response.get('validator_count')} "
+                    f"validators, "
+                    f"{canonical_response.get('total_stake_considered'):.0f} TAO)"
+                )
+                local_eligible_positive = {
+                    hk
+                    for hk in tracked_miners
+                    if self.score_tracker.is_eligible(hk)
+                    and self.score_tracker.ema_scores.get(hk, 0.0) > 0
+                }
+                if not any(hk in local_eligible_positive for hk in canonical_ranking):
+                    bt.logging.error(
+                        "Canonical ranking has no locally eligible "
+                        "candidate — skipping weight submission to avoid "
+                        "local-only winner selection."
+                    )
+                    return
+            else:
+                bt.logging.error(
+                    f"Canonical ranking unavailable for round "
+                    f"{round_id} — skipping weight submission to avoid "
+                    "validator divergence"
+                )
+                return
 
             weights = self.score_tracker.get_winner_heavy_pruning_dust_weights(
                 tracked_miners,
@@ -1249,6 +1443,7 @@ class Validator:
                 winner_weight=winner_weight,
                 dust_top_n=dust_top_n,
                 dust_decay=dust_decay,
+                canonical_ranking=canonical_ranking or None,
             )
 
             burn_hotkey = ""

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -7,6 +7,7 @@ import math
 import shutil
 import traceback
 import subprocess
+from copy import deepcopy
 from pathlib import Path
 
 # Add parent directory to path so we can import base and utils
@@ -465,6 +466,7 @@ class Validator:
             # --- Step 3 & 4: Order submissions and score ---
             scored_hotkeys = []
             submission_times = {}
+            score_tracker_snapshot = self._score_tracker_snapshot()
 
             # Restart recovery: restore already-scored miners
             already_scored = round_data.get("scored_miners") or {}
@@ -547,13 +549,32 @@ class Validator:
                 await asyncio.gather(*[_bounded_score(s, False) for s in ordered_subs])
 
             # --- Steps 5 & 6: Backfill + finalize ---
-            await self._finalize_round_scores(
+            finalized = await self._finalize_round_scores(
                 round_id, scored_hotkeys, submission_times, scoring_deadline
             )
+            if not finalized:
+                self._restore_score_tracker(score_tracker_snapshot)
 
         except Exception as e:
+            if "score_tracker_snapshot" in locals():
+                self._restore_score_tracker(score_tracker_snapshot)
             bt.logging.error(f"Error scoring round {round_id}: {e}")
             bt.logging.debug(traceback.format_exc())
+
+    def _score_tracker_snapshot(self) -> dict:
+        """Capture ScoreTracker state before applying a round."""
+        return {
+            "ema_scores": dict(self.score_tracker.ema_scores),
+            "last_raw_scores": dict(self.score_tracker.last_raw_scores),
+            "round_history": deepcopy(self.score_tracker.round_history),
+        }
+
+    def _restore_score_tracker(self, snapshot: dict):
+        """Restore ScoreTracker state after an unfinalized round."""
+        self.score_tracker.ema_scores = dict(snapshot["ema_scores"])
+        self.score_tracker.last_raw_scores = dict(snapshot["last_raw_scores"])
+        self.score_tracker.round_history = deepcopy(snapshot["round_history"])
+        self.score_tracker._recalculate_participation()
 
     def _download_round_files(self, round_id, round_data):
         """Download BAM + truth VCF and verify reference files; return paths dict or None on failure."""
@@ -881,7 +902,7 @@ class Validator:
         scored_hotkeys: list,
         submission_times: dict,
         scoring_deadline=None,
-    ):
+    ) -> bool:
         """Backfill gap miners from platform, record participation, then set weights.
 
         Order matters:
@@ -1013,7 +1034,7 @@ class Validator:
                     f"Round {round_id}: backfill fetch failed ({e}). "
                     "Skipping weight submission to avoid validator divergence."
                 )
-                return
+                return False
 
         # --- Step 4: Record round with COMPLETE hotkey set ---
         # This must happen after backfill so decay is only applied to miners
@@ -1027,8 +1048,8 @@ class Validator:
 
         # --- Step 5: Set chain weights ---
         await self._set_weights_after_round(round_id, submission_times)
-
         print(f"\n   Round {round_id} scoring complete", flush=True)
+        return True
 
     async def _run_miner_tool(
         self,
@@ -1319,122 +1340,130 @@ class Validator:
                 )
                 return
 
-            # Fetch a round-pinned canonical ranking for close-call winner
-            # selection. If the ranking is unavailable or below quorum, skip
-            # this weight update rather than submitting a local-only winner.
-            # Passing round_id avoids sampling different "latest completed"
-            # rounds during the scheduler's status-promotion interval.
-            canonical_response = await self.platform_client.get_canonical_ranking(
-                round_id=round_id
+            canonical_ranking = None
+            canonical_needed = self.score_tracker.needs_canonical_tiebreak(
+                tracked_miners,
+                submission_times,
             )
-            canonical_ranking = []
-            canonical_parse_failed = False
-            canonical_low_coverage = False
-            if canonical_response is None:
-                # Transport errors and unavailable responses are handled below
-                # by skipping this weight update.
-                pass
-            elif not isinstance(canonical_response, dict):
-                canonical_parse_failed = True
-            else:
-                ranking = canonical_response.get("ranking")
-                if not isinstance(ranking, list):
+            if canonical_needed:
+                # Fetch a round-pinned canonical ranking for close-call winner
+                # selection. If the ranking is unavailable or below quorum,
+                # skip this weight update rather than submitting a local-only
+                # close-call winner. Passing round_id avoids sampling different
+                # "latest completed" rounds during the scheduler's
+                # status-promotion interval.
+                canonical_response = await self.platform_client.get_canonical_ranking(
+                    round_id=round_id
+                )
+                canonical_ranking = []
+                canonical_parse_failed = False
+                canonical_low_coverage = False
+                if canonical_response is None:
+                    # Transport errors and unavailable responses are handled
+                    # below by skipping this weight update.
+                    pass
+                elif not isinstance(canonical_response, dict):
                     canonical_parse_failed = True
-                elif not ranking:
-                    canonical_low_coverage = True
                 else:
-                    v_count = canonical_response.get("validator_count", 0)
-                    stake_total = canonical_response.get(
-                        "total_stake_considered", 0.0
-                    )
-                    min_total_stake = (
-                        canonical_min_validator_count
-                        * canonical_min_validator_stake
-                    )
-                    if not isinstance(v_count, int) or v_count < canonical_min_validator_count:
-                        canonical_low_coverage = True
-                    elif not isinstance(stake_total, (int, float)) or stake_total < min_total_stake:
+                    ranking = canonical_response.get("ranking")
+                    if not isinstance(ranking, list):
+                        canonical_parse_failed = True
+                    elif not ranking:
                         canonical_low_coverage = True
                     else:
-                        for entry in ranking:
-                            if not isinstance(entry, dict):
-                                canonical_parse_failed = True
-                                break
-                            raw = entry.get("miner_hotkey")
-                            if not isinstance(raw, str):
-                                canonical_parse_failed = True
-                                break
-                            # Trim accidental whitespace without changing
-                            # ss58 casing.
-                            candidate = raw.strip()
-                            if not candidate:
-                                canonical_parse_failed = True
-                                break
-
-                            # Keep a validator-side quorum check for rolling
-                            # upgrades and skip only the affected entry.
-                            entry_count = entry.get("validator_count", 0)
-                            if (
-                                not isinstance(entry_count, int)
-                                or entry_count < canonical_min_validator_count
-                            ):
-                                continue
-                            canonical_ranking.append(candidate)
-
-                        if not canonical_parse_failed and not canonical_ranking:
-                            # No ranked miner met the validator-side quorum.
+                        v_count = canonical_response.get("validator_count", 0)
+                        stake_total = canonical_response.get(
+                            "total_stake_considered", 0.0
+                        )
+                        min_total_stake = (
+                            canonical_min_validator_count
+                            * canonical_min_validator_stake
+                        )
+                        if not isinstance(v_count, int) or v_count < canonical_min_validator_count:
                             canonical_low_coverage = True
+                        elif not isinstance(stake_total, (int, float)) or stake_total < min_total_stake:
+                            canonical_low_coverage = True
+                        else:
+                            for entry in ranking:
+                                if not isinstance(entry, dict):
+                                    canonical_parse_failed = True
+                                    break
+                                raw = entry.get("miner_hotkey")
+                                if not isinstance(raw, str):
+                                    canonical_parse_failed = True
+                                    break
+                                # Trim accidental whitespace without changing
+                                # ss58 casing.
+                                candidate = raw.strip()
+                                if not candidate:
+                                    canonical_parse_failed = True
+                                    break
 
-            if canonical_parse_failed:
-                bt.logging.error(
-                    f"Canonical ranking response malformed "
-                    f"(shape={type(canonical_response).__name__}); "
-                    "skipping weight submission. Check "
-                    "/scoring/canonical-ranking."
-                )
-                return
-            elif canonical_low_coverage:
-                bt.logging.error(
-                    f"Canonical ranking has insufficient coverage for "
-                    f"round {round_id} "
-                    f"(validators={canonical_response.get('validator_count')}, "
-                    f"top_validators="
-                    f"{(canonical_response.get('ranking') or [{}])[0].get('validator_count')}, "
-                    f"stake={canonical_response.get('total_stake_considered')}; "
-                    f"min={canonical_min_validator_count} validators / "
-                    f"{canonical_min_validator_stake} TAO each). Skipping "
-                    "weight submission to avoid validator divergence."
-                )
-                return
-            elif canonical_ranking:
-                bt.logging.info(
-                    f"Canonical ranking top={canonical_ranking[0][:16]}... "
-                    f"({len(canonical_ranking)} candidates) for "
-                    f"round {round_id} "
-                    f"(coverage: {canonical_response.get('validator_count')} "
-                    f"validators, "
-                    f"{canonical_response.get('total_stake_considered'):.0f} TAO)"
-                )
-                local_eligible_positive = {
-                    hk
-                    for hk in tracked_miners
-                    if self.score_tracker.is_eligible(hk)
-                    and self.score_tracker.ema_scores.get(hk, 0.0) > 0
-                }
-                if not any(hk in local_eligible_positive for hk in canonical_ranking):
+                                # Keep a validator-side quorum check for
+                                # rolling upgrades and skip only the affected
+                                # entry.
+                                entry_count = entry.get("validator_count", 0)
+                                if (
+                                    not isinstance(entry_count, int)
+                                    or entry_count < canonical_min_validator_count
+                                ):
+                                    continue
+                                canonical_ranking.append(candidate)
+
+                            if not canonical_parse_failed and not canonical_ranking:
+                                # No ranked miner met the validator-side quorum.
+                                canonical_low_coverage = True
+
+                if canonical_parse_failed:
                     bt.logging.error(
-                        "Canonical ranking has no locally eligible "
-                        "candidate — skipping weight submission to avoid "
-                        "local-only winner selection."
+                        f"Canonical ranking response malformed "
+                        f"(shape={type(canonical_response).__name__}); "
+                        "skipping weight submission. Check "
+                        "/scoring/canonical-ranking."
                     )
                     return
-            else:
-                bt.logging.error(
-                    f"Canonical ranking unavailable for round "
-                    f"{round_id} — skipping weight submission to avoid "
-                    "validator divergence"
-                )
-                return
+                elif canonical_low_coverage:
+                    bt.logging.error(
+                        f"Canonical ranking has insufficient coverage for "
+                        f"round {round_id} "
+                        f"(validators={canonical_response.get('validator_count')}, "
+                        f"top_validators="
+                        f"{(canonical_response.get('ranking') or [{}])[0].get('validator_count')}, "
+                        f"stake={canonical_response.get('total_stake_considered')}; "
+                        f"min={canonical_min_validator_count} validators / "
+                        f"{canonical_min_validator_stake} TAO each). Skipping "
+                        "weight submission to avoid validator divergence."
+                    )
+                    return
+                elif canonical_ranking:
+                    bt.logging.info(
+                        f"Canonical ranking top={canonical_ranking[0][:16]}... "
+                        f"({len(canonical_ranking)} candidates) for "
+                        f"round {round_id} "
+                        f"(coverage: {canonical_response.get('validator_count')} "
+                        f"validators, "
+                        f"{canonical_response.get('total_stake_considered'):.0f} TAO)"
+                    )
+                    local_eligible_positive = {
+                        hk
+                        for hk in tracked_miners
+                        if self.score_tracker.is_eligible(hk)
+                        and self.score_tracker.ema_scores.get(hk, 0.0) > 0
+                    }
+                    if not any(hk in local_eligible_positive for hk in canonical_ranking):
+                        bt.logging.error(
+                            "Canonical ranking has no locally eligible "
+                            "candidate — skipping weight submission to avoid "
+                            "local-only winner selection."
+                        )
+                        return
+                else:
+                    bt.logging.error(
+                        f"Canonical ranking unavailable for round "
+                        f"{round_id} — skipping weight submission to avoid "
+                        "validator divergence"
+                    )
+                    return
 
             weights = self.score_tracker.get_winner_heavy_pruning_dust_weights(
                 tracked_miners,

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ environment setup, and process management.
 
 Usage:
     python setup.py          (after install.sh, or standalone if deps are installed)
+    python setup.py --update-data-only  (non-interactive data + image refresh)
     ./install.sh             (recommended: bootstraps deps then launches this)
 """
 
@@ -44,14 +45,20 @@ def _bootstrap_deps():
 
     if missing:
         print(f"\nSetup wizard requires: {', '.join(missing)}")
-        answer = input("Install now? [Y/n] ").strip().lower()
-        if answer in ("", "y", "yes"):
+        if "--update-data-only" in sys.argv:
+            print("Installing automatically for --update-data-only...")
             subprocess.check_call(
                 [sys.executable, "-m", "pip", "install", *missing, "--quiet"]
             )
         else:
-            print("Cannot proceed without dependencies. Exiting.")
-            sys.exit(1)
+            answer = input("Install now? [Y/n] ").strip().lower()
+            if answer in ("", "y", "yes"):
+                subprocess.check_call(
+                    [sys.executable, "-m", "pip", "install", *missing, "--quiet"]
+                )
+            else:
+                print("Cannot proceed without dependencies. Exiting.")
+                sys.exit(1)
 
 _bootstrap_deps()
 
@@ -651,7 +658,7 @@ class SetupWizard:
 
     # ── Step 6: Docker images ─────────────────────────────────────────────
 
-    def step_docker_images(self) -> StepResult:
+    def step_docker_images(self, force_pull: bool = False, assume_yes: bool = False) -> StepResult:
         if self.state.role == "miner":
             # Pull all template images so the miner can switch tools without re-running setup.
             seen: set = set()
@@ -666,36 +673,53 @@ class SetupWizard:
 
         self.state.docker_images_needed = list(needed)
 
-        already = []
+        if shutil.which("docker") is None:
+            self.console.print("  [yellow]Docker is not installed; skipping image pull.[/]")
+            return StepResult(skipped=True)
+
+        existing = []
+        missing = []
         to_pull = []
         for image in needed:
             if self._docker_image_exists(image):
-                already.append(image)
+                existing.append(image)
+                if force_pull:
+                    to_pull.append(image)
             else:
+                missing.append(image)
                 to_pull.append(image)
 
         # Display table
         table = Table(show_header=True, header_style="bold cyan", padding=(0, 1))
         table.add_column("Image", style="white", max_width=55)
         table.add_column("Status", justify="center", width=10)
-        for img in already:
-            table.add_row(img, "[green]PULLED[/]")
-        for img in to_pull:
+        for img in existing:
+            status = "[cyan]REFRESH[/]" if force_pull else "[green]PULLED[/]"
+            table.add_row(img, status)
+        for img in missing:
             table.add_row(img, "[yellow]MISSING[/]")
         self.console.print(table)
 
-        self.state.docker_images_pulled = list(already)
+        self.state.docker_images_pulled = list(existing)
 
         if not to_pull:
             self.console.print("  [green]All required Docker images available.[/]")
             return StepResult()
 
-        self.console.print(f"  [dim]Total download may be several GB. This can take 5-15 minutes.[/]")
+        if force_pull:
+            self.console.print("  [dim]Refreshing configured Docker image references.[/]")
+        else:
+            self.console.print(f"  [dim]Total download may be several GB. This can take 5-15 minutes.[/]")
 
-        pull = questionary.confirm(
-            f"Pull {len(to_pull)} missing image(s)?",
-            default=True, style=CUSTOM_STYLE,
-        ).ask()
+        if assume_yes:
+            pull = True
+        else:
+            action = "Refresh" if force_pull else "Pull"
+            target = "configured image(s)" if force_pull else "missing image(s)"
+            pull = questionary.confirm(
+                f"{action} {len(to_pull)} {target}?",
+                default=True, style=CUSTOM_STYLE,
+            ).ask()
 
         if pull is None or not pull:
             self.console.print("  [yellow]Skipping. Pull images manually before running.[/]")
@@ -710,7 +734,8 @@ class SetupWizard:
             )
             if result.returncode == 0:
                 self.console.print(f"  [green]Pulled {img}[/]")
-                self.state.docker_images_pulled.append(img)
+                if img not in self.state.docker_images_pulled:
+                    self.state.docker_images_pulled.append(img)
             else:
                 self.console.print(f"  [red]Failed to pull {img}[/]")
                 failed.append(img)
@@ -809,7 +834,7 @@ class SetupWizard:
         self.console.print("  [green]Archive extracted[/]")
         return True
 
-    def step_reference_data(self) -> StepResult:
+    def step_reference_data(self, assume_yes: bool = False) -> StepResult:
         # Migrate old flat chr20 structure if detected
         self._migrate_legacy_reference_data()
 
@@ -849,10 +874,14 @@ class SetupWizard:
         total_size_mb = sum(f.get("size_mb", 0) for f in to_download)
         self.console.print(f"  [dim]Total download: ~{total_size_mb} MB[/]")
 
-        download = questionary.confirm(
-            f"Download {len(to_download)} missing file(s)?",
-            default=True, style=CUSTOM_STYLE,
-        ).ask()
+        if assume_yes:
+            self.console.print("  [dim]Downloading missing reference files without prompting.[/]")
+            download = True
+        else:
+            download = questionary.confirm(
+                f"Download {len(to_download)} missing file(s)?",
+                default=True, style=CUSTOM_STYLE,
+            ).ask()
 
         if download is None or not download:
             self.console.print("  [yellow]Skipping. Download files before running.[/]")
@@ -1566,10 +1595,7 @@ if __name__ == "__main__":
     wizard = SetupWizard()
 
     if "--update-data-only" in sys.argv:
-        # Non-interactive: just migrate legacy data + download missing reference files
-        print("\n  Checking reference data...\n")
-        wizard._migrate_legacy_reference_data()
-        # Determine role from .env if it exists
+        # Non-interactive: refresh configured Docker images and reference data.
         env_path = BASE_DIR / ".env"
         if env_path.exists():
             with open(env_path) as f:
@@ -1582,7 +1608,11 @@ if __name__ == "__main__":
                     wizard.state.role = "validator"
         else:
             wizard.state.role = "validator"  # download all (superset)
-        wizard.step_reference_data()
-        print("\n  Reference data up to date.\n")
+
+        print(f"\n  Updating {wizard.state.role} Docker images and reference data...\n")
+        wizard.step_docker_images(force_pull=True, assume_yes=True)
+        print("\n  Checking reference data...\n")
+        wizard.step_reference_data(assume_yes=True)
+        print("\n  Update-data-only finished.\n")
     else:
         wizard.run()

--- a/tests/test_weight_tracking.py
+++ b/tests/test_weight_tracking.py
@@ -367,6 +367,26 @@ class TestCanonicalTiebreak:
     and uses that as a tiebreaker only inside the tolerance band.
     """
 
+    def test_canonical_not_needed_during_warmup(self, score_tracker):
+        _make_active(score_tracker, "hk_a", rounds=1, score=0.90)
+        _make_active(score_tracker, "hk_b", rounds=1, score=0.89)
+        assert not score_tracker.needs_canonical_tiebreak(["hk_a", "hk_b"])
+
+    def test_canonical_not_needed_for_clear_local_winner(self, score_tracker):
+        _seed_eligible_emas(score_tracker, {"hk_a": 0.700, "hk_b": 0.650})
+        assert not score_tracker.needs_canonical_tiebreak(["hk_a", "hk_b"])
+
+    def test_canonical_needed_for_close_local_winner(self, score_tracker):
+        _seed_eligible_emas(score_tracker, {"hk_a": 0.700, "hk_b": 0.695})
+        assert score_tracker.needs_canonical_tiebreak(["hk_a", "hk_b"])
+
+    def test_canonical_needed_at_exact_tolerance_boundary(self, score_tracker):
+        gap = CANONICAL_TIEBREAK_TOLERANCE
+        _seed_eligible_emas(
+            score_tracker, {"hk_a": 0.70, "hk_b": 0.70 - gap}
+        )
+        assert score_tracker.needs_canonical_tiebreak(["hk_a", "hk_b"])
+
     def test_canonical_used_when_within_tolerance(self, score_tracker):
         # Local rank-1 = hk_a (0.700 EMA), rank-2 = hk_b (0.695 EMA).
         # Gap 0.5%, within 2% tolerance. Canonical says hk_b, so hk_b wins.

--- a/tests/test_weight_tracking.py
+++ b/tests/test_weight_tracking.py
@@ -11,6 +11,7 @@ from utils.weight_tracking import (
     DEFAULT_WINNER_WEIGHT,
     DEFAULT_DUST_TOP_N,
     DEFAULT_DUST_DECAY,
+    CANONICAL_TIEBREAK_TOLERANCE,
 )
 
 
@@ -51,6 +52,22 @@ def _make_active(tracker: ScoreTracker, hotkey: str, rounds: int = 1,
     for i in range(rounds):
         tracker.update(hotkey, score)
         tracker.record_round(f"active-{hotkey}-{i}", [hotkey])
+
+
+def _seed_eligible_emas(tracker: ScoreTracker, hotkey_emas: dict):
+    """Seed exact EMA values and eligibility for tolerance-boundary tests."""
+    hotkeys = list(hotkey_emas.keys())
+    for hk, ema in hotkey_emas.items():
+        tracker.ema_scores[hk] = ema
+
+    # Add participation history without changing the seeded EMA values.
+    for i in range(tracker.min_rounds):
+        tracker.round_history.append({
+            "round_id": f"seed-{i}",
+            "scored_hotkeys": list(hotkeys),
+            "active_hotkeys": list(hotkeys),
+        })
+    tracker._recalculate_participation()
 
 
 DEFAULT_REWARD_POLICY = {
@@ -336,6 +353,192 @@ class TestWinnerHeavyPruningDust:
         assert weights["hk_a"] == pytest.approx(miner_budget * 0.5 / 0.8)
         assert weights["hk_b"] == pytest.approx(miner_budget * 0.3 / 0.8)
         assert sum(weights.values()) == pytest.approx(miner_budget)
+
+
+# =========================================================================
+# TestCanonicalTiebreak
+# =========================================================================
+
+class TestCanonicalTiebreak:
+    """Canonical-ranking tiebreak when local leaders are within tolerance.
+
+    The canonical ranking comes from the platform's /scoring/canonical-ranking
+    endpoint. The validator scans it for the first locally eligible candidate
+    and uses that as a tiebreaker only inside the tolerance band.
+    """
+
+    def test_canonical_used_when_within_tolerance(self, score_tracker):
+        # Local rank-1 = hk_a (0.700 EMA), rank-2 = hk_b (0.695 EMA).
+        # Gap 0.5%, within 2% tolerance. Canonical says hk_b, so hk_b wins.
+        _seed_eligible_emas(score_tracker, {"hk_a": 0.700, "hk_b": 0.695})
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a", "hk_b"],
+            canonical_top="hk_b",
+            **DEFAULT_REWARD_POLICY,
+        )
+        assert weights["hk_b"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
+        dust_pool = 1.0 - DEFAULT_BURN_RATE - DEFAULT_WINNER_WEIGHT
+        assert weights["hk_a"] == pytest.approx(dust_pool)
+
+    def test_canonical_ignored_when_outside_tolerance(self, score_tracker):
+        # EMA gap is outside tolerance, so local rank 1 remains the winner.
+        _seed_eligible_emas(score_tracker, {"hk_a": 0.700, "hk_b": 0.640})
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a", "hk_b"],
+            canonical_top="hk_b",
+            **DEFAULT_REWARD_POLICY,
+        )
+        assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
+        dust_pool = 1.0 - DEFAULT_BURN_RATE - DEFAULT_WINNER_WEIGHT
+        assert weights["hk_b"] == pytest.approx(dust_pool)
+
+    def test_canonical_at_exact_tolerance_boundary(self, score_tracker):
+        # Boundary is inclusive.
+        gap = CANONICAL_TIEBREAK_TOLERANCE
+        _seed_eligible_emas(
+            score_tracker, {"hk_a": 0.70, "hk_b": 0.70 - gap}
+        )
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a", "hk_b"],
+            canonical_top="hk_b",
+            **DEFAULT_REWARD_POLICY,
+        )
+        assert weights["hk_b"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
+
+    def test_canonical_just_outside_tolerance(self, score_tracker):
+        # Just outside the tolerance band, local rank 1 remains the winner.
+        gap = CANONICAL_TIEBREAK_TOLERANCE + 0.001
+        _seed_eligible_emas(
+            score_tracker, {"hk_a": 0.70, "hk_b": 0.70 - gap}
+        )
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a", "hk_b"],
+            canonical_top="hk_b",
+            **DEFAULT_REWARD_POLICY,
+        )
+        assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
+
+    def test_canonical_lower_than_local_rank1_within_tolerance(self, score_tracker):
+        _seed_eligible_emas(
+            score_tracker, {"hk_a": 0.700, "hk_b": 0.715},
+        )
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a", "hk_b"],
+            canonical_top="hk_a",
+            **DEFAULT_REWARD_POLICY,
+        )
+        assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
+
+    def test_canonical_not_in_eligible_set_falls_back(self, score_tracker):
+        # A canonical hotkey outside local eligibility cannot be used.
+        _seed_eligible_emas(score_tracker, {"hk_a": 0.700, "hk_b": 0.695})
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a", "hk_b"],
+            canonical_top="hk_unknown_validator_in_some_other_subnet",
+            **DEFAULT_REWARD_POLICY,
+        )
+        assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
+
+    def test_canonical_ranking_skips_ineligible_rank1(self, score_tracker):
+        # Scan past canonical entries that are not locally eligible.
+        _seed_eligible_emas(score_tracker, {"hk_a": 0.700, "hk_b": 0.695})
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a", "hk_b"],
+            canonical_ranking=["hk_new_not_eligible", "hk_b", "hk_a"],
+            **DEFAULT_REWARD_POLICY,
+        )
+        assert weights["hk_b"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
+
+    def test_canonical_ranking_candidate_outside_tolerance_falls_back(self, score_tracker):
+        _seed_eligible_emas(score_tracker, {"hk_a": 0.700, "hk_b": 0.650})
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a", "hk_b"],
+            canonical_ranking=["hk_new_not_eligible", "hk_b"],
+            **DEFAULT_REWARD_POLICY,
+        )
+        assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
+
+    def test_no_canonical_preserves_pure_function_baseline(self, score_tracker):
+        # No canonical input preserves local EMA ranking.
+        _seed_eligible_emas(score_tracker, {"hk_a": 0.700, "hk_b": 0.695})
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a", "hk_b"],
+            canonical_top=None,
+            **DEFAULT_REWARD_POLICY,
+        )
+        assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
+
+    def test_no_canonical_matches_default_call(self, score_tracker):
+        # Explicit None and omitted canonical input should be equivalent.
+        _seed_eligible_emas(
+            score_tracker,
+            {"hk_a": 0.70, "hk_b": 0.69, "hk_c": 0.68, "hk_d": 0.67},
+        )
+        with_none = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a", "hk_b", "hk_c", "hk_d"],
+            canonical_top=None,
+            **DEFAULT_REWARD_POLICY,
+        )
+        without_kwarg = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a", "hk_b", "hk_c", "hk_d"],
+            **DEFAULT_REWARD_POLICY,
+        )
+        assert with_none == without_kwarg
+
+    def test_canonical_matches_local_rank1_is_noop(self, score_tracker):
+        _seed_eligible_emas(score_tracker, {"hk_a": 0.700, "hk_b": 0.695})
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a", "hk_b"],
+            canonical_top="hk_a",
+            **DEFAULT_REWARD_POLICY,
+        )
+        assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
+
+    def test_dust_redistribution_after_canonical_override(self, score_tracker):
+        # Three eligible miners (all within tolerance), canonical promotes
+        # rank 2 to winner. The displaced local rank 1 keeps the top dust slot.
+        _seed_eligible_emas(
+            score_tracker,
+            {"hk_a": 0.700, "hk_b": 0.695, "hk_c": 0.690},
+        )
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a", "hk_b", "hk_c"],
+            canonical_top="hk_b",
+            **DEFAULT_REWARD_POLICY,
+        )
+        assert weights["hk_b"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
+        dust_pool = 1.0 - DEFAULT_BURN_RATE - DEFAULT_WINNER_WEIGHT
+        dust_total = 1.0 + DEFAULT_DUST_DECAY
+        assert weights["hk_a"] == pytest.approx(dust_pool / dust_total)
+        assert weights["hk_c"] == pytest.approx(
+            dust_pool * DEFAULT_DUST_DECAY / dust_total
+        )
+
+    def test_canonical_with_single_eligible_miner(self, score_tracker):
+        # A single locally eligible miner remains the winner.
+        _seed_eligible_emas(score_tracker, {"hk_a": 0.90})
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a"],
+            canonical_top="hk_some_other",
+            **DEFAULT_REWARD_POLICY,
+        )
+        assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
+
+    def test_canonical_full_top10_dust_displaced_winner(self, score_tracker):
+        # Canonical rank 2 wins; local rank 1 remains first dust recipient.
+        emas = {f"hk_{i:02d}": 0.700 - i * 0.001 for i in range(1, 12)}
+        _seed_eligible_emas(score_tracker, emas)
+        miner_list = list(emas.keys())
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            miner_list,
+            canonical_top="hk_02",
+            **DEFAULT_REWARD_POLICY,
+        )
+        non_zero = [hk for hk, w in weights.items() if w > 0]
+        assert len(non_zero) == 10, f"expected 10 non-zero, got {len(non_zero)}"
+        assert weights["hk_02"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
+        assert weights["hk_11"] == 0
+        assert weights["hk_01"] > weights["hk_03"]
 
 
 # =========================================================================

--- a/tests/test_weight_tracking.py
+++ b/tests/test_weight_tracking.py
@@ -398,6 +398,10 @@ class TestCanonicalTiebreak:
         _seed_eligible_emas(
             score_tracker, {"hk_a": 0.70, "hk_b": 0.70 - gap}
         )
+        actual_gap = (
+            score_tracker.ema_scores["hk_a"] - score_tracker.ema_scores["hk_b"]
+        )
+        assert actual_gap == pytest.approx(CANONICAL_TIEBREAK_TOLERANCE)
         weights = score_tracker.get_winner_heavy_pruning_dust_weights(
             ["hk_a", "hk_b"],
             canonical_top="hk_b",
@@ -457,6 +461,18 @@ class TestCanonicalTiebreak:
             **DEFAULT_REWARD_POLICY,
         )
         assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
+
+    def test_canonical_ranking_scans_past_out_of_band_candidate(self, score_tracker):
+        _seed_eligible_emas(
+            score_tracker,
+            {"hk_a": 0.700, "hk_b": 0.690, "hk_c": 0.650},
+        )
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a", "hk_b", "hk_c"],
+            canonical_ranking=["hk_c", "hk_b", "hk_a"],
+            **DEFAULT_REWARD_POLICY,
+        )
+        assert weights["hk_b"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
 
     def test_no_canonical_preserves_pure_function_baseline(self, score_tracker):
         # No canonical input preserves local EMA ranking.

--- a/utils/platform_client.py
+++ b/utils/platform_client.py
@@ -148,6 +148,50 @@ class PlatformClient:
         except Exception:
             return None
 
+    async def get_canonical_ranking(
+        self,
+        round_id: Optional[str] = None,
+        top_n: int = 10,
+    ) -> Optional[Dict[str, Any]]:
+        """Fetch stake-weighted canonical ranking for a round.
+
+        Used by validator weight tracking as a tiebreak signal when local EMA
+        leaders are close. Returns the full response including the ranked list of
+        ``{miner_hotkey, consensus_ema, validator_count, stake_share}``.
+
+        Platform serves this only after the late-score grace period. Returns
+        ``None`` on any error; the validator treats that as canonical
+        unavailable for the round.
+
+        Args:
+            round_id: optional explicit round; defaults to platform's latest
+                completed round.
+            top_n: number of top miners to retrieve.
+        """
+        try:
+            params: Dict[str, Any] = {"top_n": top_n}
+            if round_id:
+                params["round_id"] = round_id
+            async with self._get_client() as client:
+                # Keep the canonical lookup bounded on the weight-setting
+                # path. The endpoint is expected to be cached after the
+                # final-score gate opens.
+                for attempt in range(3):
+                    response = await client.get(
+                        "/scoring/canonical-ranking",
+                        params=params,
+                        timeout=10.0,
+                    )
+                    if response.status_code == 200:
+                        return response.json()
+                    if response.status_code == 425 and attempt < 2:
+                        await asyncio.sleep(5.0)
+                        continue
+                    break
+                return None
+        except Exception:
+            return None
+
 
 class MinerPlatformClient(PlatformClient):
     """Platform client for miners."""
@@ -731,8 +775,8 @@ class ValidatorPlatformClient(PlatformClient):
     ) -> Dict[str, Any]:
         """Fetch scores for miners not personally covered this round (validator only).
 
-        Must be called after the scoring window has closed. The platform enforces
-        this gate (returns 425 Too Early if the window is still open).
+        Must be called after the scoring window and late-score grace have closed.
+        The platform enforces this gate (returns 425 Too Early until final).
 
         Args:
             round_id: The round to fetch backfill scores for.

--- a/utils/weight_tracking.py
+++ b/utils/weight_tracking.py
@@ -43,6 +43,18 @@ WARMUP_WEIGHTS = [0.50, 0.30, 0.20]
 SCORE_EPSILON = 0.005
 EMA_TOLERANCE = 1e-9
 
+# Canonical-ranking tiebreak. When a locally eligible canonical candidate is
+# within this absolute EMA gap of local rank 1, the canonical candidate is used
+# as the winner. This keeps close rounds aligned while leaving clearly separated
+# local EMA winners unchanged.
+CANONICAL_TIEBREAK_TOLERANCE = 0.02
+
+# Minimum canonical coverage. Platform contributors below the per-validator
+# stake floor are excluded, and the validator requires enough distinct
+# validators before using the canonical ranking.
+CANONICAL_MIN_VALIDATOR_COUNT = int(os.getenv("CANONICAL_MIN_VALIDATOR_COUNT", "4"))
+CANONICAL_MIN_VALIDATOR_STAKE = float(os.getenv("CANONICAL_MIN_VALIDATOR_STAKE", "5000"))
+
 # Normal phase defaults. These are absolute validator-vector weights before
 # Bittensor's u16 encoding: burn gets 0.87, rank #1 gets 0.10, and ranks
 # #2-#10 split the remaining 0.03 by geometric decay.
@@ -245,6 +257,8 @@ class ScoreTracker:
         winner_weight: float,
         dust_top_n: int,
         dust_decay: float,
+        canonical_top: Optional[str] = None,
+        canonical_ranking: Optional[List[str]] = None,
     ) -> Dict[str, float]:
         """
         Compute absolute validator-vector miner weights.
@@ -254,6 +268,16 @@ class ScoreTracker:
         splits the remaining non-burn budget across ranks #2..dust_top_n.
         Unused dust is intentionally left unallocated so the caller can add it
         to burn.
+
+        If ``canonical_ranking`` is supplied, the validator scans it in order
+        and adopts the first locally eligible positive-EMA candidate within
+        ``CANONICAL_TIEBREAK_TOLERANCE`` of local rank 1. Local EMA order still
+        controls dust allocation.
+
+        ``canonical_top`` is retained as a backwards-compatible shorthand for
+        a one-item canonical ranking.
+
+        ``canonical_top=None`` keeps the default local-EMA ranking behavior.
         """
         weights = {hk: 0.0 for hk in miner_hotkeys}
         if not miner_hotkeys:
@@ -327,11 +351,51 @@ class ScoreTracker:
             )
             return weights
 
+        # Canonical-ranking tiebreak. Scan the ranking because the platform's
+        # top miner may not yet be locally eligible on every validator.
         winner = ranked[0]
+        canonical_candidates: List[str] = []
+        if canonical_ranking:
+            seen = set()
+            for hk in canonical_ranking:
+                if not isinstance(hk, str):
+                    continue
+                if not hk or hk in seen:
+                    continue
+                canonical_candidates.append(hk)
+                seen.add(hk)
+        elif canonical_top is not None:
+            canonical_candidates = [canonical_top]
+
+        if canonical_candidates:
+            ranked_set = set(ranked)
+            top_ema = self.ema_scores.get(ranked[0], 0.0)
+            for candidate in canonical_candidates:
+                if candidate not in ranked_set:
+                    continue
+                if candidate == ranked[0]:
+                    winner = candidate
+                    break
+                canonical_ema = self.ema_scores.get(candidate, 0.0)
+                if (top_ema - canonical_ema) <= CANONICAL_TIEBREAK_TOLERANCE:
+                    winner = candidate
+                    logger.info(
+                        f"Canonical tiebreak: local rank-1 was "
+                        f"{ranked[0][:16]}... (ema={top_ema:.4f}); "
+                        f"deferring to canonical winner {candidate[:16]}... "
+                        f"(ema={canonical_ema:.4f}, gap "
+                        f"{(top_ema - canonical_ema)*100:.2f}% within "
+                        f"{CANONICAL_TIEBREAK_TOLERANCE*100:.1f}% tolerance)"
+                    )
+                    break
+
         weights[winner] = winner_weight
 
         dust_pool = max(0.0, miner_budget - winner_weight)
-        dust_recipients = ranked[1:dust_top_n]
+        # Dust remains ordered by local EMA, excluding the chosen winner. If
+        # canonical selects a non-local-rank-1 winner, the displaced local
+        # rank 1 remains eligible for the highest dust slot.
+        dust_recipients = [hk for hk in ranked if hk != winner][:dust_top_n - 1]
         if dust_pool > 0 and dust_recipients:
             dust_raw = [dust_decay ** i for i in range(len(dust_recipients))]
             dust_total = sum(dust_raw)

--- a/utils/weight_tracking.py
+++ b/utils/weight_tracking.py
@@ -248,6 +248,37 @@ class ScoreTracker:
 
         return sorted(hotkeys, key=functools.cmp_to_key(_cmp))
 
+    def _ranked_positive_eligible(
+        self,
+        miner_hotkeys: List[str],
+        submission_times: Optional[Dict[str, float]] = None,
+    ) -> List[str]:
+        """Return eligible miners with positive EMA, ordered by local EMA."""
+        eligible = [hk for hk in miner_hotkeys if self.is_eligible(hk)]
+        return [
+            hk for hk in self._sort_by_ema(
+                eligible, submission_times, tolerance=EMA_TOLERANCE
+            )
+            if self.ema_scores.get(hk, 0.0) > 0
+        ]
+
+    def needs_canonical_tiebreak(
+        self,
+        miner_hotkeys: List[str],
+        submission_times: Optional[Dict[str, float]] = None,
+    ) -> bool:
+        """Return True when canonical ranking can affect winner selection."""
+        ranked = self._ranked_positive_eligible(miner_hotkeys, submission_times)
+        if len(ranked) < 2:
+            return False
+
+        top_ema = self.ema_scores.get(ranked[0], 0.0)
+        return any(
+            (top_ema - self.ema_scores.get(hk, 0.0))
+            <= CANONICAL_TIEBREAK_TOLERANCE + EMA_TOLERANCE
+            for hk in ranked[1:]
+        )
+
     def get_winner_heavy_pruning_dust_weights(
         self,
         miner_hotkeys: List[str],
@@ -337,12 +368,7 @@ class ScoreTracker:
                 )
             return weights
 
-        ranked = [
-            hk for hk in self._sort_by_ema(
-                eligible, submission_times, tolerance=EMA_TOLERANCE
-            )
-            if self.ema_scores.get(hk, 0.0) > 0
-        ]
+        ranked = self._ranked_positive_eligible(miner_hotkeys, submission_times)
 
         if not ranked:
             logger.warning(

--- a/utils/weight_tracking.py
+++ b/utils/weight_tracking.py
@@ -377,14 +377,15 @@ class ScoreTracker:
                     winner = candidate
                     break
                 canonical_ema = self.ema_scores.get(candidate, 0.0)
-                if (top_ema - canonical_ema) <= CANONICAL_TIEBREAK_TOLERANCE:
+                gap = top_ema - canonical_ema
+                if gap <= CANONICAL_TIEBREAK_TOLERANCE + EMA_TOLERANCE:
                     winner = candidate
                     logger.info(
                         f"Canonical tiebreak: local rank-1 was "
                         f"{ranked[0][:16]}... (ema={top_ema:.4f}); "
                         f"deferring to canonical winner {candidate[:16]}... "
                         f"(ema={canonical_ema:.4f}, gap "
-                        f"{(top_ema - canonical_ema)*100:.2f}% within "
+                        f"{gap*100:.2f}% within "
                         f"{CANONICAL_TIEBREAK_TOLERANCE*100:.1f}% tolerance)"
                     )
                     break


### PR DESCRIPTION
## Summary

- add round-pinned canonical ranking lookup for validator weight setting
- use canonical ranking only for close local EMA decisions with sufficient validator/stake coverage
- skip weight submission when canonical data is unavailable, malformed, or below quorum
- wait through score grace/finalization before backfill and canonical lookup
- make `setup.py --update-data-only` non-interactive and refresh configured Docker images
- bump spec/package version to `0.1.3`