### PR TITLE
Deprecate FreeBayes + fix bcftools caller-mode default

### DIFF
--- a/.env.miner.example
+++ b/.env.miner.example
@@ -7,7 +7,8 @@ WALLET_NAME=default
 WALLET_HOTKEY=default
 
 # Variant Calling Template
-# Options: gatk, deepvariant, freebayes, bcftools
+# Options: gatk, deepvariant, bcftools
+# (freebayes deprecated 2026-05-09 16:00 UTC — submissions rejected by platform)
 # All require Docker. Images are pulled automatically.
 MINER_TEMPLATE=gatk
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ minos_subnet/
 ├── templates/                # Variant-calling tool templates
 │   ├── gatk.py               # GATK HaplotypeCaller template
 │   ├── deepvariant.py        # Google DeepVariant template
-│   ├── freebayes.py          # FreeBayes template
+│   ├── freebayes.py          # FreeBayes template (DEPRECATED 2026-05-09; retained so in-flight pre-cutover rounds can still be scored; will be removed in a follow-up release)
 │   ├── bcftools.py           # BCFtools mpileup/call template
 │   ├── _common.py            # Shared template utilities
 │   └── tool_params.py        # Parameter definitions and validation
@@ -99,7 +99,7 @@ minos_subnet/
 ├── configs/                  # Miner-tunable quality parameters
 │   ├── gatk.conf
 │   ├── deepvariant.conf
-│   ├── freebayes.conf
+│   ├── freebayes.conf        # DEPRECATED 2026-05-09; retained for legacy parsing
 │   └── bcftools.conf
 ├── docs/                     # Architecture and integration docs
 │   ├── architecture.md       # System architecture deep dive
@@ -134,7 +134,7 @@ minos_subnet/
 |-----------|-------------|-------|
 | OS | Linux (Ubuntu 20.04+), macOS 13+ | Docker + Bittensor run best on Linux |
 | CPU/RAM (Validator) | ≥8 cores / 32 GB RAM | hap.py scoring benefits from cores |
-| CPU/RAM (Miner) | ≥4 cores / 8–16 GB RAM | 8 GB for BCFtools/FreeBayes, 16 GB for DeepVariant |
+| CPU/RAM (Miner) | ≥4 cores / 8–16 GB RAM | 8 GB for BCFtools, 16 GB for DeepVariant |
 | Disk | ≥60 GB (miner) / ≥100 GB (validator) | Reference: ~2 GB miner, ~14 GB validator (SDF expands ~6×). Plus per-round BAMs (~6 GB each) until cleaned. |
 | Docker | 20.10+ (24.0+ recommended) | Required for GATK, hap.py, bcftools |
 | Python | 3.10+ | We test on 3.12 |
@@ -215,10 +215,12 @@ cp .env.validator.example .env # for validators
 ```bash
 docker pull broadinstitute/gatk:4.5.0.0
 docker pull google/deepvariant:1.5.0
-docker pull staphb/freebayes:1.3.7
 docker pull genonet/hap-py@sha256:03acabe84bbfba35f5a7234129d524c563f5657e1f21150a2ea2797f8e6d05f2
 docker pull quay.io/biocontainers/bcftools:1.20--h8b25389_0
 docker pull quay.io/biocontainers/samtools:1.20--h50ea8bc_0
+# Validators only — the freebayes image is retained until in-flight
+# pre-cutover rounds finish scoring, then removed in a follow-up release:
+# docker pull staphb/freebayes:1.3.7
 ```
 
 > **Note:** The hap.py image is pinned by SHA256 digest for reproducible scoring. The tag `genonet/hap-py:0.3.15` points to the same image but the digest is what validators use internally.
@@ -358,7 +360,7 @@ python -m neurons.miner \
 1. **Registration**: Register with platform via hotkey authentication
 2. **Task Poll**: Poll platform for pending evaluation tasks
 3. **BAM Download**: Fetch benchmark BAM from platform via presigned URL
-4. **Variant Calling**: Run configured variant caller (GATK, DeepVariant, freebayes, or bcftools)
+4. **Variant Calling**: Run configured variant caller (GATK, DeepVariant, or bcftools — freebayes deprecated 2026-05-09)
 5. **Config Submit**: Submit tool config you've used (hyperparameters only based on the template)
 6. **Reward**: Earn alpha based on accuracy score — validators re-run the config to verify
 
@@ -449,7 +451,7 @@ In the warmup phase, miners with scores within 0.5% of each other are tiebroken 
 |-------------------------------|--------------------------------------------|------------------------------------------------------------------------------------------------------------------|
 | `docker: permission denied`   | User not in docker group                   | `sudo usermod -aG docker $USER && newgrp docker`                                                                 |
 | `GATK timeout`                | Insufficient resources                     | Increase threads/memory or timeout                                                                               |
-| DeepVariant OOM / killed      | <16 GB available to the container          | DeepVariant needs ≥16 GB. Free RAM, close other tools, or switch template to GATK/FreeBayes/BCFtools             |
+| DeepVariant OOM / killed      | <16 GB available to the container          | DeepVariant needs ≥16 GB. Free RAM, close other tools, or switch template to GATK/BCFtools                       |
 | `Platform 401 error`          | Invalid sig or unregistered hotkey         | Ensure wallet hotkey is registered on the metagraph                                                              |
 | `No miners available`         | No registered miners                       | Check metagraph for active miners                                                                                |
 | `hap.py zero scores`          | VCF format issues                          | Ensure single-sample VCF output                                                                                  |

--- a/__init__.py
+++ b/__init__.py
@@ -2,8 +2,10 @@
 Minos - Genomics Variant Calling Subnet
 
 A Bittensor subnet for distributed genomic variant calling.
-Miners run GATK, DeepVariant, FreeBayes, or BCFtools to call variants;
+Miners run GATK, DeepVariant, or BCFtools to call variants;
 validators score results with hap.py.
+
+(FreeBayes was deprecated 2026-05-09 16:00 UTC.)
 """
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/configs/freebayes.conf
+++ b/configs/freebayes.conf
@@ -1,4 +1,12 @@
 # FreeBayes Quality Parameters
+#
+# DEPRECATED 2026-05-09 16:00 UTC. The platform rejects new freebayes
+# submissions with HTTP 400. This file is retained so historical rounds
+# can be replayed and the runner code parses cleanly; both the file and
+# the runner will be removed in a follow-up release once in-flight
+# pre-cutover rounds finish scoring. New miners: pick gatk, deepvariant,
+# or bcftools instead.
+#
 # Adjust these values to optimize variant calling quality.
 # Only quality-affecting params — threads, memory, timeout are auto-detected.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ Minos is a Bittensor subnet (SN107) that creates a decentralised market for geno
 
 Genomic variant calling accuracy is critical for real-world genomics, yet benchmarking is fragmented and untrustworthy. Minos turns this into a continuous, incentivized benchmarking network:
 
-- **Miners** run variant-calling pipelines (GATK, DeepVariant, FreeBayes, or BCFtools) and earn rewards proportional to their accuracy.
+- **Miners** run variant-calling pipelines (GATK, DeepVariant, or BCFtools — freebayes deprecated 2026-05-09 16:00 UTC) and earn rewards proportional to their accuracy.
 - **Validators** re-run miner configurations against private hold-out data and score results with hap.py — no trust required.
 - **The platform** generates synthetic benchmark BAMs (GIAB + HelixForge-inserted mutations) and coordinates rounds.
 
@@ -90,8 +90,8 @@ All API calls are authenticated via canonical request signing. Each request incl
 | --- | --- |
 | `gatk` | `broadinstitute/gatk:4.5.0.0` |
 | `deepvariant` | `google/deepvariant:1.5.0` |
-| `freebayes` | `staphb/freebayes:1.3.7` |
 | `bcftools` | `quay.io/biocontainers/bcftools:1.20--h8b25389_0` |
+| `freebayes` | `staphb/freebayes:1.3.7` (DEPRECATED 2026-05-09; runner retained while in-flight pre-cutover rounds finish scoring, then removed in a follow-up release) |
 
 Miners tune quality parameters via `configs/<tool>.conf`. Infrastructure parameters (`threads`, `memory_gb`, `timeout`, `ref_build`, `num_threads`) are stripped before submission and cannot influence scoring.
 
@@ -187,7 +187,7 @@ minos_subnet/
 ├── templates/
 │   ├── gatk.py            # GATK HaplotypeCaller template
 │   ├── deepvariant.py     # Google DeepVariant template
-│   ├── freebayes.py       # FreeBayes template
+│   ├── freebayes.py       # FreeBayes template (DEPRECATED 2026-05-09)
 │   ├── bcftools.py        # BCFtools mpileup/call template
 │   ├── _common.py         # Shared template utilities
 │   └── tool_params.py     # Parameter definitions and validation
@@ -205,7 +205,7 @@ minos_subnet/
 ├── configs/
 │   ├── gatk.conf          # Miner-tunable GATK quality parameters
 │   ├── deepvariant.conf   # Miner-tunable DeepVariant parameters
-│   ├── freebayes.conf     # Miner-tunable FreeBayes parameters
+│   ├── freebayes.conf     # Miner-tunable FreeBayes parameters (DEPRECATED 2026-05-09)
 │   └── bcftools.conf      # Miner-tunable BCFtools parameters
 ├── docs/
 │   ├── architecture.md    # This document

--- a/docs/tuning_guide.md
+++ b/docs/tuning_guide.md
@@ -66,8 +66,9 @@ Four tools are supported. Pick based on your hardware and willingness to tune.
 |-----------------------|----------|---------|------------|---------------------------------|
 | GATK HaplotypeCaller  | Highest  | Slowest | Most knobs | Maximizing score, if you have time to tune |
 | DeepVariant           | High     | Medium  | Few knobs  | Consistent high scores with minimal tuning |
-| FreeBayes             | Good     | Medium  | Moderate   | Good balance of speed and accuracy |
 | bcftools mpileup      | Lower    | Fastest | Moderate   | Quick testing, low-resource setups |
+
+> **FreeBayes was deprecated on 2026-05-09 16:00 UTC.** The platform rejects new freebayes submissions; switch to GATK, DeepVariant, or BCFtools.
 
 **Recommendation:** Start with DeepVariant if you want reliable scores fast. Move to GATK if you want to squeeze out every point and are willing to iterate.
 
@@ -96,14 +97,15 @@ Only quality-related parameters are exposed. Infrastructure params (threads, mem
 
 DeepVariant is intentionally less tunable — it relies on its trained model. Your main lever is `min_mapping_quality`. The defaults are generally strong.
 
-### FreeBayes
+### FreeBayes (DEPRECATED 2026-05-09 16:00 UTC)
+
+> **No longer accepted by the platform.** New submissions with `tool_name=freebayes`
+> return HTTP 400. The reference below is retained for historical context only.
 
 | Parameter                | Default | Effect                                                                         |
 |--------------------------|---------|--------------------------------------------------------------------------------|
 | `min_alternate_fraction` | 0.05    | Minimum variant allele frequency to call. Lower = more sensitive but more FPs. |
 | `min_mapping_quality`    | 1       | Filter poorly mapped reads. Consider raising to 10-20.                         |
-
-**Tuning priority:** `min_alternate_fraction` is your main lever. The default 0.05 is sensitive — raise toward 0.1-0.2 if your FP rate is too high, or keep it low if completeness is suffering.
 
 ### bcftools mpileup
 
@@ -193,8 +195,8 @@ Config files live in your miner's `configs/` directory:
 ```
 configs/gatk.conf
 configs/deepvariant.conf
-configs/freebayes.conf
 configs/bcftools.conf
+configs/freebayes.conf      # DEPRECATED 2026-05-09
 ```
 
 ### Format
@@ -223,11 +225,8 @@ model_type=WGS
 min_mapping_quality=10
 ```
 
-**FreeBayes:**
-```ini
-min_alternate_fraction=0.05
-min_mapping_quality=1
-```
+> Note: FreeBayes minimal-config example was removed because the tool was deprecated on 2026-05-09 16:00 UTC.
+
 
 ---
 

--- a/min_compute.yml
+++ b/min_compute.yml
@@ -30,7 +30,7 @@ compute_spec:
       recommended_gpu: "NVIDIA T4 or better (optional for DeepVariant)" # GPU recommendation
 
     memory:
-      min_ram: 8            # Minimum RAM (GB) - GATK/FreeBayes/BCFtools run on 8GB; DeepVariant needs 16GB
+      min_ram: 8            # Minimum RAM (GB) - GATK/BCFtools run on 8GB; DeepVariant needs 16GB
       min_swap: 8           # Minimum swap space (GB)
       recommended_ram: 16   # Recommended RAM (required for DeepVariant template)
       recommended_swap: 16  # Recommended swap space (GB)
@@ -61,8 +61,8 @@ compute_spec:
         # Pull ONE of the following depending on MINER_TEMPLATE:
         - "broadinstitute/gatk:4.5.0.0"        # gatk template (~4GB, default)
         - "google/deepvariant:1.5.0"            # deepvariant template (~6GB)
-        - "staphb/freebayes:1.3.7"              # freebayes template (~500MB, also needs bcftools)
         - "quay.io/biocontainers/bcftools:1.20--h8b25389_0" # bcftools template (~500MB)
+        # freebayes deprecated 2026-05-09 16:00 UTC — image removed from miner pull list.
 
   validator:
 
@@ -113,7 +113,7 @@ compute_spec:
         - "genonet/hap-py:0.3.15"              # hap.py + RTG Tools scoring (~2GB)
         - "broadinstitute/gatk:4.5.0.0"        # GATK template (~4GB)
         - "google/deepvariant:1.5.0"            # DeepVariant template (~6GB)
-        - "staphb/freebayes:1.3.7"              # FreeBayes template (~500MB)
+        - "staphb/freebayes:1.3.7"              # FreeBayes template (~500MB) — DEPRECATED 2026-05-09; retained so in-flight pre-cutover rounds can be scored; removed in a follow-up release
         - "quay.io/biocontainers/bcftools:1.20--h8b25389_0" # BCFtools template + scoring (~500MB)
         - "quay.io/biocontainers/samtools:1.20--h50ea8bc_0" # samtools for BAM indexing (~500MB)
 

--- a/neurons/README.md
+++ b/neurons/README.md
@@ -31,7 +31,7 @@ A miner receives genomic data (DNA sequencing files) and finds genetic variants 
 
 3. **Process the Data**
    - Download the BAM file (raw genomic data) from platform presigned URL
-   - Run variant calling tool  (GATK, DeepVariant, FreeBayes, or BCFtools) locally with your preferred configs to ensure quality output
+   - Run variant calling tool  (GATK, DeepVariant, or BCFtools) locally with your preferred configs to ensure quality output
    - This analyzes the DNA data and identifies variants
 
 4. **Return Results**
@@ -86,7 +86,7 @@ python -m neurons.miner
 | `WALLET_HOTKEY` | default | Bittensor hotkey name |
 | `PLATFORM_URL` | https://api.theminos.ai | Platform API URL |
 | `PLATFORM_TIMEOUT` | 60 | Platform API request timeout (seconds) |
-| `MINER_TEMPLATE` | gatk | Variant calling tool: `gatk`, `deepvariant`, `freebayes`, or `bcftools` |
+| `MINER_TEMPLATE` | gatk | Variant calling tool: `gatk`, `deepvariant`, or `bcftools` (freebayes deprecated 2026-05-09) |
 | `STORAGE_PRIMARY_BACKEND` | hippius | Storage preference: `hippius` tries Hippius SN75 first (Bittensor decentralized, recommended). `aws_s3` reverses the order. |
 
 ## Validator (validator.py)

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -35,6 +35,7 @@ from utils.config_loader import extract_tool_options, get_tool_version
 
 # Template system for pluggable variant callers
 from templates import (
+    DEPRECATED_TEMPLATES,
     get_template_path,
     load_template,
 )
@@ -146,11 +147,22 @@ class Miner:
         """Setup variant caller from MINER_TEMPLATE env var."""
         self.variant_caller = os.getenv("MINER_TEMPLATE", "").lower() or MINER_CONFIG.get("default_caller", "gatk")
 
+        # Refuse to run with a deprecated template. The runner is still
+        # registered (validators need it for in-flight pre-cutover rounds),
+        # so a stray MINER_TEMPLATE value would otherwise resolve, run, and
+        # waste compute on every round before the platform's HTTP 400.
+        if self.variant_caller in DEPRECATED_TEMPLATES:
+            bt.logging.error(
+                f"MINER_TEMPLATE='{self.variant_caller}' is deprecated. "
+                f"{DEPRECATED_TEMPLATES[self.variant_caller]}"
+            )
+            sys.exit(1)
+
         # Validate template exists
         try:
             get_template_path(self.variant_caller)
         except (ValueError, FileNotFoundError):
-            bt.logging.error(f"Invalid template '{self.variant_caller}'. Available: gatk, deepvariant, freebayes, bcftools")
+            bt.logging.error(f"Invalid template '{self.variant_caller}'. Available: gatk, deepvariant, bcftools")
             sys.exit(1)
 
     @staticmethod
@@ -162,7 +174,7 @@ class Miner:
         parser.add_argument(
             "--variant_caller",
             type=str,
-            choices=["gatk", "deepvariant", "freebayes", "bcftools"],
+            choices=["gatk", "deepvariant", "bcftools"],
             default=MINER_CONFIG.get("default_caller", "gatk"),
             help="Variant calling template",
         )
@@ -541,8 +553,6 @@ class Miner:
                 base_config["gatk_options"] = tool_options
             elif self.variant_caller == "deepvariant":
                 base_config["deepvariant_options"] = tool_options
-            elif self.variant_caller == "freebayes":
-                base_config["freebayes_options"] = tool_options
             elif self.variant_caller == "bcftools":
                 base_config["bcftools_options"] = tool_options
 
@@ -557,8 +567,6 @@ class Miner:
                 base_config["gatk_options"] = {"min_base_quality_score": 10}
             elif self.variant_caller == "deepvariant":
                 base_config["deepvariant_options"] = {"model_type": "WGS"}
-            elif self.variant_caller == "freebayes":
-                base_config["freebayes_options"] = {"min_mapping_quality": 1}
             elif self.variant_caller == "bcftools":
                 base_config["bcftools_options"] = {"min_BQ": 1}
 

--- a/neurons/status.py
+++ b/neurons/status.py
@@ -49,18 +49,19 @@ MINER_DOCKER_IMAGES = {
     "deepvariant": [
         "google/deepvariant:1.5.0",
     ],
-    "freebayes": [
-        "staphb/freebayes:1.3.7",
-    ],
     "bcftools": [
         "quay.io/biocontainers/bcftools:1.20--h8b25389_0",
     ],
+    # freebayes is intentionally absent — see DEPRECATED_TEMPLATES in
+    # templates/__init__.py and the runtime block in neurons/miner.py.
 }
 
 VALIDATOR_DOCKER_IMAGES = [
     "genonet/hap-py@sha256:03acabe84bbfba35f5a7234129d524c563f5657e1f21150a2ea2797f8e6d05f2",
     "broadinstitute/gatk:4.5.0.0",
     "google/deepvariant:1.5.0",
+    # Retained only so validators can replay in-flight pre-cutover rounds;
+    # removed in a follow-up release.
     "staphb/freebayes:1.3.7",
     "quay.io/biocontainers/bcftools:1.20--h8b25389_0",
     "quay.io/biocontainers/samtools:1.20--h50ea8bc_0",
@@ -217,6 +218,16 @@ def check_docker_daemon() -> Check:
 
 def check_docker_images(role: str, template: Optional[str]) -> List[Check]:
     if role == "miner" and template:
+        # Surface deprecated miner templates as a FAIL so this matches the
+        # runtime block in neurons/miner.py — keeps `verify`/`status` output
+        # honest instead of pretending freebayes is a valid miner choice.
+        from templates import DEPRECATED_TEMPLATES  # local import to avoid cycle
+        if template in DEPRECATED_TEMPLATES:
+            return [Check(
+                name="Variant caller template",
+                status=Status.FAIL,
+                detail=f"'{template}' is deprecated; {DEPRECATED_TEMPLATES[template]}",
+            )]
         images = MINER_DOCKER_IMAGES.get(template, [])
     elif role == "miner":
         images = MINER_DOCKER_IMAGES.get("gatk", [])

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -11,7 +11,7 @@
 #      and attempts to submit — the platform responds with "demo complete"
 #   5. This script inspects the output VCF and prints a summary
 #
-# Usage: bash scripts/demo.sh [--template gatk|deepvariant|freebayes|bcftools]
+# Usage: bash scripts/demo.sh [--template gatk|deepvariant|bcftools]
 #        Run from the minos_subnet/ directory.
 set -euo pipefail
 
@@ -46,7 +46,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -h|--help)
-            echo "Usage: bash scripts/demo.sh [--template gatk|deepvariant|freebayes|bcftools]"
+            echo "Usage: bash scripts/demo.sh [--template gatk|deepvariant|bcftools]"
             echo ""
             echo "Runs a single demo round to verify your miner setup."
             echo "If --template is not specified, the value from .env is used (default: gatk)."
@@ -54,7 +54,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         *)
             echo -e "${RED}Unknown argument: $1${NC}"
-            echo "Usage: bash scripts/demo.sh [--template gatk|deepvariant|freebayes|bcftools]"
+            echo "Usage: bash scripts/demo.sh [--template gatk|deepvariant|bcftools]"
             exit 1
             ;;
     esac
@@ -63,10 +63,10 @@ done
 # Validate template choice if provided
 if [[ -n "$TEMPLATE" ]]; then
     case "$TEMPLATE" in
-        gatk|deepvariant|freebayes|bcftools) ;;
+        gatk|deepvariant|bcftools) ;;
         *)
             echo -e "${RED}Invalid template: $TEMPLATE${NC}"
-            echo "Valid options: gatk, deepvariant, freebayes, bcftools"
+            echo "Valid options: gatk, deepvariant, bcftools"
             exit 1
             ;;
     esac
@@ -425,7 +425,7 @@ echo -e "  ${BOLD}Tips to improve your score:${NC}"
 echo -e "    - Tune parameters in ${CYAN}configs/$ACTIVE_TEMPLATE.conf${NC}"
 echo -e "    - Try different variant callers (GATK and DeepVariant score highest)"
 echo -e "    - Ensure enough RAM is available for your tool"
-echo -e "      (DeepVariant: 8GB+, GATK: 4GB+, bcftools/freebayes: 2GB+)"
+echo -e "      (DeepVariant: 8GB+, GATK: 4GB+, bcftools: 2GB+)"
 echo ""
 
 # ---------------------------------------------------------------------------

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -70,12 +70,16 @@ echo "Docker images:"
 MINER_IMAGES=(
     "broadinstitute/gatk:4.5.0.0"
     "google/deepvariant:1.5.0"
-    "staphb/freebayes:1.3.7"
     "quay.io/biocontainers/bcftools:1.20--h8b25389_0"
     "quay.io/biocontainers/samtools:1.20--h50ea8bc_0"
 )
 VALIDATOR_IMAGES=(
     "genonet/hap-py@sha256:03acabe84bbfba35f5a7234129d524c563f5657e1f21150a2ea2797f8e6d05f2"
+)
+# Images required only for replaying historical pre-cutover rounds. Will be
+# removed in a follow-up release once those rounds finish scoring.
+DEPRECATED_VALIDATOR_IMAGES=(
+    "staphb/freebayes:1.3.7"
 )
 
 check_images() {
@@ -90,12 +94,24 @@ check_images() {
     done
 }
 
+check_deprecated_images() {
+    for img in "$@"; do
+        short="${img##*/}"
+        if docker image inspect "$img" &>/dev/null; then
+            warn "$short present (deprecated; retained only for historical rounds)"
+        else
+            pass "$short not pulled (deprecated; not required for new rounds)"
+        fi
+    done
+}
+
 if [[ "$ROLE" == "--miner" ]]; then
     check_images "${MINER_IMAGES[@]}"
     echo -e "  ${YELLOW}Note:${NC} You only need the image for your chosen variant caller."
 elif [[ "$ROLE" == "--validator" ]]; then
     check_images "${VALIDATOR_IMAGES[@]}"
     check_images "${MINER_IMAGES[@]}"
+    check_deprecated_images "${DEPRECATED_VALIDATOR_IMAGES[@]}"
 fi
 
 # --- Wallet ---

--- a/setup.py
+++ b/setup.py
@@ -102,12 +102,13 @@ MINER_DOCKER_IMAGES = {
     "deepvariant": [
         "google/deepvariant:1.5.0",
     ],
-    "freebayes": [
-        "staphb/freebayes:1.3.7",
-    ],
     "bcftools": [
         "quay.io/biocontainers/bcftools:1.20--h8b25389_0",
     ],
+    # freebayes deprecated 2026-05-09 16:00 UTC. Image stays in
+    # VALIDATOR_DOCKER_IMAGES so validators can score any in-flight
+    # pre-cutover freebayes submissions; it will be removed in a
+    # follow-up release once those rounds have settled.
 }
 
 VALIDATOR_DOCKER_IMAGES = [
@@ -605,7 +606,7 @@ class SetupWizard:
         if self.state.role != "miner":
             self.console.print("  [dim]Template selection is for miners only.[/]")
             self.console.print(
-                "  [dim]Validators re-run all miner tool configs (GATK, DeepVariant, FreeBayes, BCFtools) and score with hap.py.[/]"
+                "  [dim]Validators re-run all miner tool configs (GATK, DeepVariant, BCFtools) and score with hap.py.[/]"
             )
             self.console.print(
                 "  [dim]All required Docker images will be configured in the next step.[/]"
@@ -620,10 +621,6 @@ class SetupWizard:
             questionary.Choice(
                 "DeepVariant             (GPU-accelerated, Google AI)",
                 value="deepvariant",
-            ),
-            questionary.Choice(
-                "FreeBayes               (Bayesian caller, lightweight)",
-                value="freebayes",
             ),
             questionary.Choice(
                 "BCFtools                (minimal, fastest)",
@@ -646,13 +643,12 @@ class SetupWizard:
         info = {
             "gatk": ("broadinstitute/gatk:4.5.0.0", "~4 GB", "10-20 min/window"),
             "deepvariant": ("google/deepvariant:1.5.0", "~3 GB", "5-15 min (GPU) / 15-30 min (CPU)"),
-            "freebayes": ("staphb/freebayes:1.3.7", "~500 MB", "5-15 min/window"),
             "bcftools": ("quay.io/biocontainers/bcftools:1.20--h8b25389_0", "~200 MB", "2-5 min/window"),
         }
         image, size, timing = info[template]
         self.console.print(f"  Primary image: [cyan]{image}[/] ({size})")
         self.console.print(f"  Typical runtime: {timing}")
-        self.console.print(f"  [dim]All 4 tool images will be pulled so you can switch templates later.[/]")
+        self.console.print(f"  [dim]All 3 tool images will be pulled so you can switch templates later.[/]")
 
         return StepResult()
 

--- a/start-miner.sh
+++ b/start-miner.sh
@@ -22,7 +22,7 @@ show_help() {
     echo "Options:"
     echo "  --wallet-name <name>        Wallet name"
     echo "  --wallet-hotkey <name>      Hotkey name"
-    echo "  --miner-template <tool>     Variant caller: gatk, deepvariant, freebayes, bcftools"
+    echo "  --miner-template <tool>     Variant caller: gatk, deepvariant, bcftools"
     echo "  --storage <backend>         Fetch order: hippius (default) or aws_s3 (R2/AWS first)"
     echo "  --setup                     Re-run interactive setup wizard"
     echo "  --help                      Show this help message"
@@ -31,7 +31,7 @@ show_help() {
     echo "  bash start-miner.sh                                    # First run: interactive setup"
     echo "  bash start-miner.sh --wallet-name miner --miner-template deepvariant"
     echo "  bash start-miner.sh --setup                            # Re-run setup wizard"
-    echo "  bash start-miner.sh --miner-template freebayes         # Change tool and restart"
+    echo "  bash start-miner.sh --miner-template bcftools          # Change tool and restart"
     exit 0
 }
 
@@ -109,6 +109,17 @@ if [ -f .env ] && [ "$RUN_SETUP" = false ]; then
         CHANGED=true
     fi
     if [ -n "$FLAG_MINER_TEMPLATE" ]; then
+        case "$FLAG_MINER_TEMPLATE" in
+            gatk|deepvariant|bcftools) ;;
+            freebayes)
+                echo -e "${RED}freebayes was deprecated 2026-05-09 16:00 UTC. Choose gatk, deepvariant, or bcftools.${NC}"
+                exit 1
+                ;;
+            *)
+                echo -e "${RED}invalid --miner-template '$FLAG_MINER_TEMPLATE'. Choose gatk, deepvariant, or bcftools.${NC}"
+                exit 1
+                ;;
+        esac
         sed -i.bak "s/^MINER_TEMPLATE=.*/MINER_TEMPLATE=$FLAG_MINER_TEMPLATE/" .env && rm -f .env.bak
         MINER_TEMPLATE="$FLAG_MINER_TEMPLATE"
         CHANGED=true
@@ -211,8 +222,8 @@ if [ ! -f .env ] || [ "$RUN_SETUP" = true ]; then
     # Tool selection — highlight current default
     echo ""
     echo -e "${BLUE}[2/2] Select variant calling tool:${NC}"
-    TOOLS=("gatk" "deepvariant" "freebayes" "bcftools")
-    LABELS=("GATK HaplotypeCaller" "DeepVariant" "FreeBayes" "BCFtools")
+    TOOLS=("gatk" "deepvariant" "bcftools")
+    LABELS=("GATK HaplotypeCaller" "DeepVariant" "BCFtools")
     for i in "${!TOOLS[@]}"; do
         MARKER=""
         [ "${TOOLS[$i]}" = "$DEFAULT_MINER_TEMPLATE" ] && MARKER=" ${GREEN}(current)${NC}"
@@ -225,13 +236,12 @@ if [ ! -f .env ] || [ "$RUN_SETUP" = true ]; then
         [ "${TOOLS[$i]}" = "$DEFAULT_MINER_TEMPLATE" ] && DEFAULT_TOOL_NUM=$((i+1))
     done
 
-    read -p "  Choice (1/2/3/4) [$DEFAULT_TOOL_NUM]: " TOOL_CHOICE
+    read -p "  Choice (1/2/3) [$DEFAULT_TOOL_NUM]: " TOOL_CHOICE
 
     case ${TOOL_CHOICE:-$DEFAULT_TOOL_NUM} in
         1) MINER_TEMPLATE="gatk" ;;
         2) MINER_TEMPLATE="deepvariant" ;;
-        3) MINER_TEMPLATE="freebayes" ;;
-        4) MINER_TEMPLATE="bcftools" ;;
+        3) MINER_TEMPLATE="bcftools" ;;
         *) MINER_TEMPLATE="$DEFAULT_MINER_TEMPLATE" ;;
     esac
 

--- a/templates/__init__.py
+++ b/templates/__init__.py
@@ -22,6 +22,14 @@ TEMPLATES = {
     "bcftools": "bcftools.py",
 }
 
+# Templates retained in the registry so validators can score in-flight
+# pre-cutover submissions, but rejected when chosen by miners. Miner
+# entry-points (`neurons/miner.py`, `start-miner.sh`) check this set and
+# refuse to run; the platform also returns HTTP 400 for new submissions.
+DEPRECATED_TEMPLATES = {
+    "freebayes": "Deprecated 2026-05-09 16:00 UTC. Use gatk, deepvariant, or bcftools.",
+}
+
 DEFAULT_TEMPLATE = "gatk"
 
 

--- a/templates/bcftools.py
+++ b/templates/bcftools.py
@@ -75,6 +75,24 @@ def variant_call(
             mpileup_flags.append(flag_info)
 
     mpileup_flags_str = " ".join(mpileup_flags) if mpileup_flags else ""
+
+    # `bcftools call` requires a caller-mode flag (`-m` for multiallelic,
+    # `-c` for consensus). The previous default `-mv` was only injected
+    # when call_flags was completely empty; submissions that included
+    # other call-stage params (e.g. `prior`, `pval_threshold`) produced
+    # a malformed `bcftools call` invocation that exited non-zero. Force
+    # a caller mode whenever neither is present.
+    def _has_caller_mode(flags: list[str]) -> bool:
+        for f in flags:
+            tok = f.split()[0]
+            if tok in ("-m", "--multiallelic-caller", "-c", "--consensus-caller"):
+                return True
+        return False
+
+    if call_flags and not _has_caller_mode(call_flags):
+        call_flags = ["-m"] + call_flags
+        logger.info("bcftools.call: no caller mode in submitted flags; defaulting to -m")
+
     call_flags_str = " ".join(call_flags) if call_flags else "-mv"
 
     start_time = time.time()

--- a/utils/README.md
+++ b/utils/README.md
@@ -212,7 +212,7 @@ await client.submit_score(
    |
 2. download_file_with_fallback() -> fetch BAM
    |
-3. execute_template() (GATK/DeepVariant/FreeBayes/BCFtools via Docker)
+3. execute_template() (GATK/DeepVariant/BCFtools via Docker)
    |
 4. MinerPlatformClient.submit_config()
 ```

--- a/utils/config_loader.py
+++ b/utils/config_loader.py
@@ -51,7 +51,9 @@ def extract_tool_options(tool: str) -> Dict[str, Any]:
     Load tool-specific quality parameters from .conf file.
 
     Args:
-        tool: Tool name (gatk, deepvariant, freebayes, bcftools)
+        tool: Tool name (gatk, deepvariant, bcftools).
+              freebayes still resolves through TOOL_VERSIONS so historical
+              rounds can be parsed; new submissions are blocked at the platform.
 
     Returns:
         Dict with parameter names and their values.
@@ -97,7 +99,7 @@ def get_tool_version(tool: str) -> str:
 
 
 if __name__ == "__main__":
-    for tool in ["gatk", "deepvariant", "freebayes", "bcftools"]:
+    for tool in ["gatk", "deepvariant", "bcftools"]:
         print(f"\n{tool.upper()} Config:")
         print("=" * 60)
         try:

--- a/utils/platform_client.py
+++ b/utils/platform_client.py
@@ -257,7 +257,9 @@ class MinerPlatformClient(PlatformClient):
 
         Args:
             round_id: The round ID to submit to
-            tool_name: One of "gatk", "deepvariant", "freebayes", "bcftools"
+            tool_name: One of "gatk", "deepvariant", "bcftools".
+                       (freebayes deprecated 2026-05-09 16:00 UTC; platform
+                       returns HTTP 400 for new freebayes submissions.)
             tool_config: Full tool configuration as JSON
             variant_count: Optional number of variants called
             runtime_seconds: Optional runtime in seconds


### PR DESCRIPTION
## Summary

1. **FreeBayes deprecated 2026-05-09 16:00 UTC.** Removes FreeBayes from miner-facing UX (setup wizard, CLI picker, env example, docs). Validator-side runner and registry entries are retained for now and will be removed in a follow-up release.

2. **bcftools caller-mode default.** `bcftools call` requires either `-m` or `-c`. The previous default `-mv` was only injected when `call_flags` was empty; configs that specified other call-stage params (e.g. `prior`, `pval_threshold`) without a caller mode produced a malformed invocation. The runner now prepends `-m` whenever no caller mode is present.

Bumps `__version__` 0.1.3 → 0.1.4.