### PR TITLE
Use round-only advanced scores for validator weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ minos_subnet/
 │   └── tool_params.py        # Parameter definitions and validation
 ├── utils/                    # Genomics utility modules
 │   ├── scoring.py            # hap.py Docker runner + AdvancedScorer
-│   ├── weight_tracking.py    # EMA score tracker + winner-heavy pruning dust weights
+│   ├── weight_tracking.py    # Round score tracker + winner-heavy pruning dust weights
 │   ├── platform_client.py    # Authenticated API client (miner + validator)
 │   ├── subset_scoring.py     # Subset scoring helpers (assignments, deadlines)
 │   ├── config_loader.py      # Tool config file parser
@@ -95,7 +95,7 @@ minos_subnet/
 │   ├── file_utils.py         # SHA256-verified file download + caching
 │   └── README.md             # Utils documentation
 ├── base/                     # Core subnet config
-│   └── genomics_config.py    # Central config (Docker images, timeouts, EMA params)
+│   └── genomics_config.py    # Central config (Docker images, timeouts, scoring params)
 ├── configs/                  # Miner-tunable quality parameters
 │   ├── gatk.conf
 │   ├── deepvariant.conf
@@ -107,11 +107,14 @@ minos_subnet/
 │   └── hap_py_docker.md      # hap.py Docker image reference
 ├── scripts/                  # Developer tools
 │   ├── verify.sh             # Pre-flight environment check
-│   └── demo.sh               # End-to-end demo runner
+│   ├── demo.sh               # End-to-end demo runner
+│   └── auto_update.sh        # PM2 auto-update worker used by enable_auto_update.sh
 ├── tests/                    # Unit and integration tests
 │   ├── conftest.py
 │   └── test_*.py             # Tests for scoring, config, platform client, etc.
 ├── install.sh                # Installer (full setup or update mode)
+├── enable_auto_update.sh     # Enable safe git pull + PM2 restart updates
+├── disable_auto_update.sh    # Stop the PM2 auto-updater
 ├── setup.py                  # Interactive setup wizard
 ├── start-miner.sh            # Start miner (with inline wallet setup)
 ├── start-validator.sh        # Start validator (with inline wallet setup)
@@ -180,6 +183,30 @@ pm2 start ecosystem.miner.config.js
 ```
 
 Useful commands: **`pm2 status`**, **`pm2 logs minos-validator`** / **`pm2 logs minos-miner`**, **`pm2 save`** (persist process list after reboot — pair with **`pm2 startup`** per PM2 docs). The interactive setup wizard can also generate **`ecosystem.<role>.config.js`** when you choose the PM2 process-manager option.
+
+### Automatic Updates with PM2
+
+If your miner or validator already runs under PM2, you can enable safe automatic git pulls and PM2 restarts:
+
+```bash
+./enable_auto_update.sh
+```
+
+The setup script finds likely PM2 miner/validator processes, asks you to confirm the exact process, then starts a small PM2 updater named **`minos-auto-update`**.
+
+Safety rules:
+
+- Local git changes or untracked files make the updater skip the pull.
+- Only fast-forward git updates are applied.
+- Only the PM2 process you confirmed is restarted.
+- The selected repo, branch, and PM2 process are saved in `~/.minos/auto_update.env`.
+
+Useful commands:
+
+```bash
+pm2 logs minos-auto-update
+./disable_auto_update.sh
+```
 
 ### Updating
 
@@ -381,8 +408,8 @@ The Minos Platform is a hosted service at `https://api.theminos.ai` that handles
 | `POST /v2/get-assignment`       | Validator | Get primary/secondary miner scoring assignment |
 | `POST /v2/submit-score`         | Validator | Submit per-miner scores                        |
 | `POST /v2/get-backfill-scores`  | Validator | Fetch peer scores after scoring window closes  |
-| `POST /v2/submit-weight-history`| Validator | Submit EMA scores and weights after round      |
-| `POST /v2/get-validator-state`  | Validator | Recover EMA state after validator restart       |
+| `POST /v2/submit-weight-history`| Validator | Submit round scores, eligibility, and weights   |
+| `POST /v2/get-validator-state`  | Validator | Recover round score state after validator restart |
 
 ### Storage Backends
 
@@ -418,28 +445,23 @@ Validators run each miner's tool config and score the resulting VCF from that ag
 | FP Rate      | 15%    |
 | Quality      | 10%    |
 
-### EMA Weight Tracking
+### Round Score Tracking
 
-The raw AdvancedScorer output (0–100) is normalized to a 0–1 scale before feeding into the EMA. Scores are smoothed over time using Exponential Moving Average:
+The raw AdvancedScorer output (0-100) is normalized to a 0-1 scale and used as the miner's score for that round. Winners are selected from the current round's valid Advanced Score only; historical score carryover is not used.
 
 ```python
-# AdvancedScorer returns 0-100, normalized to 0-1 for EMA
+# AdvancedScorer returns 0-100, normalized to 0-1 for round scoring
 combined_final = advanced_score / 100.0
-# EMA starts at 0; first round yields 10% of first score
-ema = (1 - alpha) * ema + alpha * combined_final
-# alpha = 0.1 (10% weight on new scores)
-# Example: raw score 85/100 → combined_final 0.85 → EMA ~0.085 after first round
+current_score = combined_final
 ```
+
+Only finite scores where `0 < current_score <= 1.0` are eligible for ranking. Rounds with no valid local or backfilled scores fail closed and do not reuse previous-round scores. The validator and platform also filter the synthetic all-zero input fingerprint around 0.25 so empty or invalid calls cannot become winners.
 
 ### Weight Distribution
 
-Weights are assigned in two phases:
+Validators burn 87% of their weight, give the top eligible current-round miner 10%, and split the remaining 3% as ranked pruning dust across eligible ranks #2 through #10 using 0.8 geometric weighting. If fewer dust recipients exist, that 3% is renormalized across the available ranks; if no dust recipients exist, unused dust is sent to burn.
 
-**Warmup** (before any miner has reached eligibility): the non-burn miner budget is split among the top 3 active miners by EMA score — 50% to 1st, 30% to 2nd, 20% to 3rd. If fewer than three active miners have positive EMA, the split is renormalized across the active positive-score set.
-
-**Normal** (once any miner reaches eligibility): validators burn 87% of their weight, give the top eligible miner 10%, and split the remaining 3% as ranked pruning dust across eligible ranks #2 through #10 using a 0.8 geometric decay. If fewer dust recipients exist, that 3% is renormalized across the available ranks; if no dust recipients exist, unused dust is sent to burn. Eligibility requires scoring in at least 10 of the last 20 rounds. Miners below the participation threshold receive 0 weight in normal mode. Absent miners' EMA decays each round they miss (×0.95), preventing stale scores from holding weight indefinitely.
-
-In the warmup phase, miners with scores within 0.5% of each other are tiebroken by earliest config submission time. In the normal phase, tiebreaks only apply when EMA scores are essentially identical (floating-point tolerance).
+Eligibility requires scoring in at least 10 of the last 20 rounds, including the current round. Miners below the participation threshold receive 0 weight until they qualify. Close current-round ties use deterministic round data from the validator/platform flow; historical scores are not part of the ranking.
 
 ---
 
@@ -458,7 +480,7 @@ In the warmup phase, miners with scores within 0.5% of each other are tiebroken 
 | Round skipped, "<10min left"  | Submitted too late                         | Miner needs ≥10 min remaining to start a round. Check clock skew (`timedatectl`) and platform connectivity speed |
 | Reference download stuck/slow | Platform redirect or transient network     | Setup retries once automatically. If it still fails, re-run `bash install.sh --update-only`                      |
 | Validator: "no scoring rounds"| Round still in submission window           | Validators only score AFTER the submission window closes. Wait for the next tempo boundary                       |
-| Earning 0 weight as miner     | Not eligible yet, or eligible but not the top EMA miner | Need >=10 of last 20 rounds participated, then a higher EMA than competitors. See [tuning_guide](docs/tuning_guide.md) |
+| Earning 0 weight as miner     | Not eligible yet, no valid current score, or outside the top current-round winners | Need >=10 of last 20 rounds participated, then a stronger current-round Advanced Score. See [tuning_guide](docs/tuning_guide.md) |
 
 ### Logs
 

--- a/disable_auto_update.sh
+++ b/disable_auto_update.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Disable Minos automatic updates on this machine.
+
+set -euo pipefail
+
+UPDATER_NAME="minos-auto-update"
+CONFIG_FILE="${HOME}/.minos/auto_update.env"
+
+if ! command -v pm2 >/dev/null 2>&1; then
+  echo "PM2 is not installed, so no PM2 updater process can be stopped."
+else
+  if pm2 describe "$UPDATER_NAME" >/dev/null 2>&1; then
+    pm2 delete "$UPDATER_NAME"
+    pm2 save
+    echo "Stopped PM2 updater: ${UPDATER_NAME}"
+  else
+    echo "No PM2 updater process named ${UPDATER_NAME} was running."
+  fi
+fi
+
+if [[ -f "$CONFIG_FILE" ]]; then
+  echo "Keeping config file for reference: ${CONFIG_FILE}"
+  echo "Remove it manually if you do not want to keep the selected process/branch."
+fi
+
+echo "Auto-update is disabled."

--- a/docs/tuning_guide.md
+++ b/docs/tuning_guide.md
@@ -25,18 +25,18 @@ Validators compare your VCF output against a truth VCF using **hap.py** (the GA4
 
 **Quality** checks biological plausibility. For WGS data, Ti/Tv should be around 2.0 and Het/Hom around 1.5. Large deviations indicate systematic errors in your calls.
 
-### EMA Smoothing and Winner-Takes-All
+### Round Scores and Winner Weights
 
-The AdvancedScorer outputs a raw score on a 0–100 scale. This is normalized to 0–1 before feeding into the EMA (so a raw score of 85/100 becomes 0.85 in EMA). Your EMA is smoothed with alpha = 0.1:
+The AdvancedScorer outputs a raw score on a 0–100 scale. Validators normalize that to a 0–1 current-round score, so a raw score of 85/100 becomes 0.85. Miner rankings are round-only: each round is a separate challenge, and the current-round score decides the paid ranks for that round.
 
-- A single bad round does not destroy you, but persistent low scores will drag your EMA down.
-- It takes roughly 10 rounds for the EMA to mostly reflect your current performance.
-- Missing rounds applies a decay factor of 0.95 per missed round to your EMA.
-- When reading logs: `Score: 85.00/100  EMA: 0.0850` is a typical first-round result with alpha = 0.1. The score is 0–100; the EMA is 0–1 and moves gradually.
+- A single bad round costs that round, not future rounds.
+- There is no EMA decay for missed rounds in the current scoring path.
+- Eligibility still depends on recent participation: miners must have valid positive scores in at least 10 of the last 20 rounds.
+- When reading logs: `Score: 85.00/100` means the current-round score is 0.85 after normalization.
 
-**Warmup phase** (until any miner has participated in 10+ rounds): the non-burn miner budget is split among the top 3 active miners by EMA — 50% to 1st, 30% to 2nd, 20% to 3rd, renormalized if fewer than three active miners have positive EMA.
+**Before eligibility:** miners receive 0 weight until they have enough recent valid scored rounds. Validators keep the unassigned budget in burn rather than paying ineligible miners.
 
-**Normal phase** (after warmup): **winner-heavy with pruning dust** among eligible miners — validators burn 87%, give rank #1 10%, and split the remaining 3% across eligible ranks #2 through #10 with ranked decay. Ineligible miners and ranks below the dust cutoff get 0.
+**After eligibility:** **winner-heavy with pruning dust** among eligible miners — validators burn 87%, give rank #1 10%, and split the remaining 3% across eligible ranks #2 through #10 with ranked decay. Ineligible miners and ranks below the dust cutoff get 0.
 
 Consistency matters as much as peak performance.
 
@@ -46,7 +46,7 @@ This is the most common question for new miners. There are three distinct causes
 
 **1. You are not eligible yet (most likely).** Eligibility requires participating in **at least 10 of the last 20 rounds**. With ~20 rounds per day, a fresh miner needs roughly 12 hours of continuous uptime before they can earn any weight, even with perfect scores. During this time you appear in validator logs but receive 0 weight. This is expected.
 
-**2. You are eligible but outside the paid ranks.** Once eligible, the top miner gets the main 10% miner weight and eligible ranks #2 through #10 split the pruning dust. If your EMA is below the paid cutoff, you get 0. The fix is to score better — see Section 4 (Tuning Strategy).
+**2. You are eligible but outside the paid ranks.** Once eligible, the top miner gets the main 10% miner weight and eligible ranks #2 through #10 split the pruning dust. If your current-round score ranks below the paid cutoff, you get 0. The fix is to score better — see Section 4 (Tuning Strategy).
 
 **3. You are submitting but the score is 0.** Causes: wrong reference build, malformed VCF (multi-sample, missing index), tool config rejected by the parameter whitelist, or a Docker error. Check your logs for the line `Score: 0.00/100`. If you see it, the variant call ran but produced no usable output. If you do not see a score line at all, your submission never made it to the scoring phase — check the platform connectivity / round timing.
 
@@ -54,13 +54,13 @@ A useful sanity check: if your logs show `Submitted config for round 2026-XX-XXT
 
 ### What If I Restart Mid-Round?
 
-The EMA state is recovered from the platform on startup, so your historical performance is not lost. Already-scored miners in the current round are skipped on the next pass — no double-scoring or wasted compute. There is no manual recovery step needed.
+Recent participation state is recovered from the platform on startup, so eligibility is not lost during a restart. Already-scored miners in the current round are skipped on the next pass — no double-scoring or wasted compute. There is no manual recovery step needed.
 
 ---
 
 ## 2. Choosing Your Variant Caller
 
-Four tools are supported. Pick based on your hardware and willingness to tune.
+Three active tools are supported. Pick based on your hardware and willingness to tune.
 
 | Tool                  | Accuracy | Speed   | Tunability | Best For                        |
 |-----------------------|----------|---------|------------|---------------------------------|
@@ -143,7 +143,7 @@ The FP rate penalty ramps steeply once you exceed the dynamic threshold. If your
 
 ### Step 5: Test Locally First
 
-Use demo mode to run test jobs locally before committing to live rounds. A bad config can tank your EMA for 10+ rounds due to the smoothing.
+Use demo mode to run test jobs locally before committing to live rounds. A bad config can cost the current round and may fail to count toward eligibility if it produces no valid positive score.
 
 ### The Core Tradeoff
 
@@ -168,7 +168,7 @@ The scoring weights (60% F1, 15% completeness, 15% FP) mean you want to lean sli
 | 40-60   | Something is suboptimal. Check tool parameters and Docker image.  |
 | Below 40| Likely a configuration error. See Common Mistakes below.          |
 
-The genomic region (chr20, 5MB windows from 10MB-55MB) varies per round, so some score variance is normal. Focus on your EMA trend, not individual rounds.
+The genomic region (chr20, 5MB windows from 10MB-55MB) varies per round, so some score variance is normal. Focus on your current-round score trend and consistency across regions.
 
 ---
 
@@ -180,11 +180,11 @@ The genomic region (chr20, 5MB windows from 10MB-55MB) varies per round, so some
 
 **Not using PCR-free mode for GATK.** GIAB donors use PCR-free library prep. Running GATK with the default `CONSERVATIVE` PCR indel model introduces unnecessary indel filtering. Set `pcr_indel_model=NONE`.
 
-**Timeout from too few threads.** While you cannot control thread count directly (it is an infrastructure parameter), make sure your Docker environment has enough resources. If your job times out before the submission window closes, you get a zero for that round — devastating for your EMA.
+**Timeout from too few threads.** While you cannot control thread count directly (it is an infrastructure parameter), make sure your Docker environment has enough resources. If your job times out before the submission window closes, you get no valid positive score for that round and may miss an eligibility count.
 
 **Ignoring Ti/Tv ratio.** A Ti/Tv ratio significantly below 2.0 for WGS usually means you are calling many false SNPs. Check your quality filters rather than accepting a low Quality component score.
 
-**Changing too many parameters at once.** With EMA smoothing at alpha=0.1, it takes many rounds to see the true effect of changes. Methodical single-parameter tuning is the only reliable approach.
+**Changing too many parameters at once.** Because each region is a different challenge, changing several knobs at once makes it hard to tell what helped. Methodical single-parameter tuning is the only reliable approach.
 
 ---
 
@@ -237,4 +237,4 @@ min_mapping_quality=10
 3. Set PCR-free mode if using GATK.
 4. Tune one parameter at a time, watching your per-component scores.
 5. Keep your FP rate low — the penalty ramps steeply past the threshold.
-6. Be patient — EMA smoothing means results take rounds to stabilize.
+6. Be patient — eligibility takes 10 valid scored rounds, and region-to-region variance is normal.

--- a/enable_auto_update.sh
+++ b/enable_auto_update.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Enable safe automatic updates for this Minos miner or validator.
+#
+# What this does:
+#   1. Finds the PM2 process that runs your miner or validator.
+#   2. Saves the selected process name in ~/.minos/auto_update.env.
+#   3. Starts a small PM2 updater named "minos-auto-update".
+#
+# The updater is intentionally cautious:
+#   - It skips updates when your git checkout has local changes.
+#   - It only pulls fast-forward updates from the current branch.
+#   - It restarts only the PM2 process you confirm here.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_DIR="${HOME}/.minos"
+CONFIG_FILE="${CONFIG_DIR}/auto_update.env"
+UPDATER_NAME="minos-auto-update"
+UPDATER_SCRIPT="${ROOT_DIR}/scripts/auto_update.sh"
+
+green() { printf '\033[0;32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[1;33m%s\033[0m\n' "$*"; }
+red() { printf '\033[0;31m%s\033[0m\n' "$*"; }
+info() { printf '%s\n' "$*"; }
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    red "Missing required command: $1"
+    if [[ "$1" == "pm2" ]]; then
+      info "Install PM2 with: npm install -g pm2"
+    fi
+    exit 1
+  fi
+}
+
+quote_env() {
+  # Print a value safely for a simple shell env file.
+  printf "%q" "$1"
+}
+
+detect_role() {
+  local text
+  text="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$text" == *validator* ]]; then
+    printf "validator"
+  elif [[ "$text" == *miner* ]]; then
+    printf "miner"
+  else
+    printf "unknown"
+  fi
+}
+
+candidate_rows() {
+  local repo="$1"
+  pm2 jlist | node -e '
+const fs = require("fs");
+const repo = process.argv[1];
+const input = fs.readFileSync(0, "utf8");
+let rows = [];
+try {
+  const processes = JSON.parse(input);
+  rows = processes
+    .map((proc) => {
+      const env = proc.pm2_env || {};
+      const name = proc.name || "";
+      const cwd = env.pm_cwd || "";
+      const script = env.pm_exec_path || env.script || "";
+      const args = Array.isArray(env.args) ? env.args.join(" ") : String(env.args || "");
+      const haystack = `${name} ${cwd} ${script} ${args}`.toLowerCase();
+      const role = haystack.includes("validator")
+        ? "validator"
+        : haystack.includes("miner")
+          ? "miner"
+          : "unknown";
+      let score = 0;
+      if (cwd === repo) score += 5;
+      if (cwd.startsWith(repo)) score += 3;
+      if (name.toLowerCase().includes("minos")) score += 2;
+      if (role !== "unknown") score += 4;
+      if (script.toLowerCase().includes("start-validator") || script.toLowerCase().includes("start-miner")) score += 3;
+      return { name, role, cwd, script, score };
+    })
+    .filter((row) => row.score > 0)
+    .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
+} catch (error) {
+  process.exit(2);
+}
+for (const row of rows) {
+  console.log([row.name, row.role, row.cwd, row.script].join("\t"));
+}
+' "$repo"
+}
+
+choose_process() {
+  local rows_file="$1"
+  local count
+  count="$(wc -l < "$rows_file" | tr -d ' ')"
+
+  if [[ "$count" == "0" ]]; then
+    yellow "No likely Minos PM2 process was detected."
+    info "Run 'pm2 list' and enter the exact PM2 process name to update."
+    read -r -p "PM2 process name: " selected_name
+    selected_role="$(detect_role "$selected_name")"
+    return
+  fi
+
+  info ""
+  info "Detected PM2 process candidates:"
+  local index=1
+  while IFS=$'\t' read -r name role cwd script; do
+    printf "  %s) %s  [%s]\n" "$index" "$name" "$role"
+    printf "     cwd: %s\n" "${cwd:-unknown}"
+    printf "     script: %s\n" "${script:-unknown}"
+    index=$((index + 1))
+  done < "$rows_file"
+
+  if [[ "$count" == "1" ]]; then
+    local name role cwd script
+    IFS=$'\t' read -r name role cwd script < "$rows_file"
+    info ""
+    read -r -p "Use PM2 process '${name}' for auto-update? [Y/n]: " answer
+    answer="${answer:-Y}"
+    if [[ ! "$answer" =~ ^[Yy]$ ]]; then
+      read -r -p "PM2 process name: " selected_name
+      selected_role="$(detect_role "$selected_name")"
+      return
+    fi
+    selected_name="$name"
+    selected_role="$role"
+    return
+  fi
+
+  info ""
+  read -r -p "Select PM2 process number to update: " choice
+  if ! [[ "$choice" =~ ^[0-9]+$ ]] || (( choice < 1 || choice > count )); then
+    red "Invalid selection."
+    exit 1
+  fi
+
+  local line
+  line="$(sed -n "${choice}p" "$rows_file")"
+  IFS=$'\t' read -r selected_name selected_role _ <<< "$line"
+}
+
+require_command git
+require_command pm2
+require_command node
+
+if [[ ! -f "${UPDATER_SCRIPT}" ]]; then
+  red "Missing updater script: ${UPDATER_SCRIPT}"
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  red "This folder is not a git repository: ${ROOT_DIR}"
+  exit 1
+fi
+
+BRANCH="$(git branch --show-current)"
+if [[ -z "$BRANCH" ]]; then
+  red "Could not detect the current git branch."
+  exit 1
+fi
+
+REMOTE="${MINOS_AUTO_UPDATE_REMOTE:-origin}"
+if ! git remote get-url "$REMOTE" >/dev/null 2>&1; then
+  red "Git remote '${REMOTE}' was not found."
+  exit 1
+fi
+
+tmp_rows="$(mktemp)"
+trap 'rm -f "$tmp_rows"' EXIT
+candidate_rows "$ROOT_DIR" > "$tmp_rows"
+
+selected_name=""
+selected_role=""
+choose_process "$tmp_rows"
+
+if [[ -z "$selected_name" ]]; then
+  red "No PM2 process selected."
+  exit 1
+fi
+
+mkdir -p "$CONFIG_DIR"
+cat > "$CONFIG_FILE" <<EOF
+# Minos auto-update settings.
+# Edit this file only if you rename your PM2 process or move the repo.
+MINOS_AUTO_UPDATE_REPO=$(quote_env "$ROOT_DIR")
+MINOS_AUTO_UPDATE_REMOTE=$(quote_env "$REMOTE")
+MINOS_AUTO_UPDATE_BRANCH=$(quote_env "$BRANCH")
+MINOS_AUTO_UPDATE_PM2_PROCESS=$(quote_env "$selected_name")
+MINOS_AUTO_UPDATE_ROLE=$(quote_env "${selected_role:-unknown}")
+MINOS_AUTO_UPDATE_INTERVAL_SECONDS=${MINOS_AUTO_UPDATE_INTERVAL_SECONDS:-300}
+MINOS_AUTO_UPDATE_ALLOW_DIRTY=0
+MINOS_AUTO_UPDATE_LOG=$(quote_env "${CONFIG_DIR}/auto_update.log")
+EOF
+
+chmod 600 "$CONFIG_FILE"
+chmod +x "$UPDATER_SCRIPT"
+
+info ""
+green "Saved auto-update config:"
+info "  ${CONFIG_FILE}"
+info "  repo: ${ROOT_DIR}"
+info "  branch: ${BRANCH}"
+info "  process: ${selected_name}"
+
+if pm2 describe "$UPDATER_NAME" >/dev/null 2>&1; then
+  pm2 restart "$UPDATER_NAME" --update-env
+else
+  pm2 start "$UPDATER_SCRIPT" --name "$UPDATER_NAME" --interpreter bash
+fi
+
+pm2 save
+
+info ""
+green "Auto-update is enabled."
+info "View logs with: pm2 logs ${UPDATER_NAME}"
+info "The updater will skip pulls if this repo has local git changes."

--- a/neurons/README.md
+++ b/neurons/README.md
@@ -113,9 +113,9 @@ A validator uses miners config file and selected hyperparameters to run the vari
 
 3. **Backfill and Update Weights**
    - After scoring window closes, fetch peer scores for miners not personally covered
-   - Track personal and backfilled scores with EMA (exponential moving average)
+   - Track personal and backfilled current-round AdvancedScorer scores
    - Record round participation once with the complete personal + backfilled hotkey set
-   - Compute warmup split or winner-heavy pruning dust weights from EMA
+   - Compute winner-heavy pruning dust weights from eligible current-round scores
    - Submit weight history to the platform for aggregation/dashboarding
    - Submit weights to Bittensor blockchain only when the validator hotkey is registered
 
@@ -162,8 +162,8 @@ python -m neurons.validator
 | `PLATFORM_URL` | https://api.theminos.ai | Platform API URL |
 | `PLATFORM_TIMEOUT` | 60 | Platform API request timeout (seconds) |
 | `STORAGE_PRIMARY_BACKEND` | hippius | Storage preference: `hippius` tries Hippius SN75 first (Bittensor decentralized, recommended). `aws_s3` reverses the order. |
-| `EMA_ALPHA` | 0.1 | EMA smoothing factor (higher = more weight on recent scores) |
-| `EMA_DECAY_FACTOR` | 0.95 | EMA decay multiplier applied per missed round |
+| `MIN_PARTICIPATION_ROUNDS` | 10 | Valid scored rounds required inside the recent eligibility window |
+| `PARTICIPATION_WINDOW` | 20 | Recent finalized rounds considered for eligibility |
 | `SCORING_THREADS` | auto | Override: threads per scoring Docker job. Auto-tuned from cores (clamped 2–8) |
 | `SCORING_MEMORY_GB` | 16 | Override: memory per scoring Docker job. **Below 16 OOM-crashes DeepVariant** |
 | `MINOS_VALIDATOR_CONCURRENCY` | auto | Override: concurrent miner jobs. Auto = `min(cores//threads, ram_gb//16, 8)` |
@@ -203,7 +203,7 @@ python -m neurons.validator
 │                          VALIDATOR                               │
 │  5. Re-run each miner's tool config locally                      │
 │  6. Score with hap.py against merged truth                       │
-│  7. Update EMA scores, winner-heavy pruning dust weights         │
+│  7. Score current round and compute pruning dust weights         │
 │  8. Submit weights to blockchain                                 │
 └──────────────────────────┬──────────────────────────────────────┘
                            ▼
@@ -216,11 +216,13 @@ python -m neurons.validator
 
 ### Weight Distribution
 
-Weights are assigned in two phases:
-
-**Warmup** (before any miner has scored in ≥10 rounds): the non-burn miner budget is split among the top 3 active miners with positive EMA — 50% to 1st, 30% to 2nd, 20% to 3rd, renormalized if fewer than three qualify. Scores within 0.5% of each other are tiebroken by earliest submission time.
-
-**Normal** (once any miner reaches eligibility): validators burn 87%, give the top eligible miner 10%, and split the remaining 3% across eligible ranks #2 through #10 using ranked pruning dust. Eligibility requires scoring in at least 10 of the last 20 rounds; ineligible miners receive 0 weight in normal mode. Absent miners' EMA decays each round they miss (×0.95). Tiebreaker: earliest submission timestamp (applied only at floating-point tolerance).
+Validators burn 87%, give the top eligible miner 10%, and split the remaining
+3% across eligible ranks #2 through #10 using ranked pruning dust. Eligibility
+requires at least 10 valid scored rounds in the last 20 finalized rounds, and
+the current round counts toward that threshold. Eligible miners are ranked only
+by the current round's AdvancedScorer score; ineligible miners receive 0
+weight. Tiebreaker: earliest submission timestamp (applied only at
+floating-point tolerance).
 
 ## Requirements
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -8,6 +8,7 @@ import shutil
 import traceback
 import subprocess
 from copy import deepcopy
+from collections import defaultdict
 from pathlib import Path
 
 # Add parent directory to path so we can import base and utils
@@ -66,6 +67,28 @@ BITTENSOR_BLOCK_TIME_SECONDS = 12
 MAX_SLEEP_SECONDS = 120
 SCORE_GRACE_SECONDS = int(os.getenv("SCORE_GRACE_SECONDS", "60"))
 SCORE_FINALIZATION_DELAY_SECONDS = int(os.getenv("SCORE_FINALIZATION_DELAY_SECONDS", "5"))
+
+
+def _valid_round_score(value, *, label: str) -> Optional[float]:
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        bt.logging.warning(f"Skipping {label}: invalid combined_final={value!r}")
+        return None
+
+    if not math.isfinite(score) or score <= 0.0 or score > 1.0:
+        bt.logging.warning(f"Skipping {label}: out-of-range combined_final={score!r}")
+        return None
+
+    return score
+
+
+def _is_zero_input_advanced_fingerprint(metrics: dict, combined_final: float) -> bool:
+    return (
+        (metrics.get("f1_snp") or 0.0) == 0.0
+        and (metrics.get("f1_indel") or 0.0) == 0.0
+        and 0.24999 <= combined_final <= 0.25001
+    )
 
 
 def auto_scoring_config():
@@ -153,8 +176,7 @@ class Validator:
         self.score_tracker = ScoreTracker(
             alpha=GENOMICS_CONFIG["ema_alpha"],
         )
-        bt.logging.info(f"Score tracker initialized (EMA alpha={GENOMICS_CONFIG['ema_alpha']}, "
-                       f"min_rounds={self.score_tracker.min_rounds})")
+        bt.logging.info("Score tracker initialized (round-only winner policy; EMA disabled)")
 
         self.setup_genomics_components()
         self.setup_platform_client()
@@ -380,11 +402,15 @@ class Validator:
                 print(f"   Region: {round_info.get('region', 'unknown')}", flush=True)
                 print(f"   Submissions: {submission_count}", flush=True)
 
-                await self._score_round_submissions(round_id)
-
-                # Mark round as scored after processing all submissions
-                self.scored_rounds.add(round_id)
-                bt.logging.info(f"Round {round_id}: marked as scored")
+                finalized = await self._score_round_submissions(round_id)
+                if finalized:
+                    self.scored_rounds.add(round_id)
+                    bt.logging.info(f"Round {round_id}: marked as scored")
+                else:
+                    bt.logging.warning(
+                        f"Round {round_id}: not marked scored; will retry until "
+                        "weights/history finalize successfully"
+                    )
 
             return {"next_scoring_window_start": next_scoring_start}
 
@@ -397,7 +423,7 @@ class Validator:
             bt.logging.debug(traceback.format_exc())
             return {"next_scoring_window_start": None}
 
-    async def _score_round_submissions(self, round_id: str):
+    async def _score_round_submissions(self, round_id: str) -> bool:
         """Score submissions for a single round using subset-based assignment.
 
         Flow:
@@ -411,7 +437,7 @@ class Validator:
         rid_check = validate_round_id(round_id)
         if not rid_check["valid"]:
             bt.logging.error(f"_score_round_submissions: invalid round_id '{round_id}': {rid_check['error']}")
-            return
+            return False
 
         try:
             # --- Step 1: Fetch assignment from platform ---
@@ -449,11 +475,11 @@ class Validator:
 
             if not submissions:
                 bt.logging.info(f"Round {round_id}: no submissions")
-                return
+                return False
 
             download_result = self._download_round_files(round_id, round_data)
             if download_result is None:
-                return
+                return False
 
             work_dir = download_result["work_dir"]
             bam_path = download_result["bam_path"]
@@ -473,11 +499,11 @@ class Validator:
             if already_scored:
                 print(f"   Restart recovery: {len(already_scored)} miners already scored, skipping", flush=True)
                 for hotkey, score_info in already_scored.items():
-                    combined_final = score_info.get("combined_final")
+                    combined_final = _valid_round_score(
+                        score_info.get("combined_final"),
+                        label=f"restored score for {hotkey[:16]}...",
+                    )
                     if combined_final is None:
-                        bt.logging.warning(
-                            f"Skipping restored score for {hotkey[:16]}...: missing AdvancedScorer combined_final"
-                        )
                         continue
                     self.score_tracker.update(hotkey, combined_final)
                     scored_hotkeys.append(hotkey)
@@ -554,12 +580,15 @@ class Validator:
             )
             if not finalized:
                 self._restore_score_tracker(score_tracker_snapshot)
+                return False
+            return True
 
         except Exception as e:
             if "score_tracker_snapshot" in locals():
                 self._restore_score_tracker(score_tracker_snapshot)
             bt.logging.error(f"Error scoring round {round_id}: {e}")
             bt.logging.debug(traceback.format_exc())
+            return False
 
     def _score_tracker_snapshot(self) -> dict:
         """Capture ScoreTracker state before applying a round."""
@@ -567,6 +596,8 @@ class Validator:
             "ema_scores": dict(self.score_tracker.ema_scores),
             "last_raw_scores": dict(self.score_tracker.last_raw_scores),
             "round_history": deepcopy(self.score_tracker.round_history),
+            "participation_counts": dict(self.score_tracker._participation_counts),
+            "recorded_round_ids": set(self.score_tracker._recorded_round_ids),
         }
 
     def _restore_score_tracker(self, snapshot: dict):
@@ -574,7 +605,12 @@ class Validator:
         self.score_tracker.ema_scores = dict(snapshot["ema_scores"])
         self.score_tracker.last_raw_scores = dict(snapshot["last_raw_scores"])
         self.score_tracker.round_history = deepcopy(snapshot["round_history"])
-        self.score_tracker._recalculate_participation()
+        self.score_tracker._participation_counts = defaultdict(
+            int, snapshot.get("participation_counts", {})
+        )
+        self.score_tracker._recorded_round_ids = set(
+            snapshot.get("recorded_round_ids", set())
+        )
 
     def _download_round_files(self, round_id, round_data):
         """Download BAM + truth VCF and verify reference files; return paths dict or None on failure."""
@@ -784,11 +820,9 @@ class Validator:
             if not result.get("success"):
                 bt.logging.warning(f"Miner {miner_hotkey[:16]}: tool failed - {result.get('error')}")
                 print(f"   Tool failed: {result.get('error', 'Unknown error')[:100]}", flush=True)
-                # Submit zero score for failed runs
-                await self._submit_miner_score(round_id, miner_hotkey, None, 0)
-                # Still counts as participation (they submitted, tool just failed)
-                self.score_tracker.update(miner_hotkey, 0.0)
-                scored_hotkeys.append(miner_hotkey)
+                bt.logging.warning(
+                    f"Miner {miner_hotkey[:16]}: no valid local score; leaving for backfill"
+                )
                 return
 
             variant_count = result.get("variant_count", 0)
@@ -846,18 +880,42 @@ class Validator:
                 if self.is_registered:
                     bt.logging.warning(f"VCF upload failed for {miner_hotkey[:16]}: {e}")
 
-            # 7. Submit score to platform (with VCF S3 keys)
+            if metrics is None:
+                print("   Scoring failed; no local score recorded", flush=True)
+                bt.logging.warning(
+                    f"Miner {miner_hotkey[:16]}: hap.py returned no valid metrics; leaving for backfill"
+                )
+                return
+
+            # 7. Validate and submit score to platform (with VCF S3 keys)
+            print(f"   SNP F1={metrics.get('f1_snp', 0):.4f}  INDEL F1={metrics.get('f1_indel', 0):.4f}", flush=True)
+            advanced_score = AdvancedScorer.compute_advanced_score(metrics)
+            combined_final = _valid_round_score(
+                advanced_score / 100.0,
+                label=f"local score for {miner_hotkey[:16]}...",
+            )
+            if combined_final is None:
+                print("   Invalid score; no local score recorded", flush=True)
+                return
+            if _is_zero_input_advanced_fingerprint(metrics, combined_final):
+                bt.logging.warning(
+                    f"Miner {miner_hotkey[:16]}: AdvancedScorer all-zero-input fingerprint; "
+                    "not submitting or ranking locally"
+                )
+                print("   Invalid zero-input score; no local score recorded", flush=True)
+                return
+
             score_result = await self._submit_miner_score(
                 round_id, miner_hotkey, metrics, scoring_elapsed,
                 output_vcf_s3_key=output_vcf_s3_key,
                 output_vcf_sha256=output_vcf_sha256_val,
                 happy_output_s3_key=happy_output_s3_key,
             )
-
-            if metrics is None:
-                print("   Scoring failed; submitted score 0.0", flush=True)
-                self.score_tracker.update(miner_hotkey, 0.0)
-                scored_hotkeys.append(miner_hotkey)
+            if not score_result:
+                bt.logging.warning(
+                    f"Miner {miner_hotkey[:16]}: platform did not accept local score; leaving for backfill"
+                )
+                print("   Platform rejected/failed score; no local score recorded", flush=True)
                 return
 
             # 8. Parse and submit variant-level results (non-blocking).
@@ -880,21 +938,17 @@ class Validator:
             except Exception as e:
                 bt.logging.warning(f"Variant results submission failed for {miner_hotkey[:16]}: {e}")
 
-            # Log results and update EMA
-            print(f"   SNP F1={metrics.get('f1_snp', 0):.4f}  INDEL F1={metrics.get('f1_indel', 0):.4f}", flush=True)
-            advanced_score = AdvancedScorer.compute_advanced_score(metrics)
-            combined_final = advanced_score / 100.0
-            ema = self.score_tracker.update(miner_hotkey, combined_final)
+            # Log results and update current-round score
+            round_score = self.score_tracker.update(miner_hotkey, combined_final)
             scored_hotkeys.append(miner_hotkey)
-            print(f"   Score: {advanced_score:.2f}/100  EMA: {ema:.4f}", flush=True)
+            print(f"   Score: {advanced_score:.2f}/100  Round score: {round_score:.4f}", flush=True)
 
         except Exception as e:
             bt.logging.error(f"Error scoring miner {miner_hotkey[:16]}: {e}")
             print(f"   Error: {str(e)[:100]}", flush=True)
-            # Submit zero score on error
-            await self._submit_miner_score(round_id, miner_hotkey, None, 0)
-            self.score_tracker.update(miner_hotkey, 0.0)
-            scored_hotkeys.append(miner_hotkey)
+            bt.logging.warning(
+                f"Miner {miner_hotkey[:16]}: exception produced no valid local score; leaving for backfill"
+            )
 
     async def _finalize_round_scores(
         self,
@@ -910,7 +964,7 @@ class Validator:
         2. Fetch backfill scores for miners not personally covered.
         3. Feed each backfill score into ScoreTracker.update().
         4. Call record_round() ONCE with the complete set (personal + backfill).
-        5. Set chain weights from the full EMA state.
+        5. Set chain weights from the finalized current-round state.
         """
         # --- Step 1: Wait for scoring window + late-score grace to close ---
         score_grace_seconds = SCORE_GRACE_SECONDS
@@ -958,8 +1012,9 @@ class Validator:
                 await asyncio.sleep(wait_secs + 5)
 
         # --- Step 2: Fetch backfill scores from platform ---
-        # Build the complete set of hotkeys (personal + backfill) before calling
-        # record_round() so decay is applied correctly to truly absent miners only.
+        # Build the complete set of hotkeys (valid local scores + backfill)
+        # before calling record_round(). Failed local attempts are deliberately
+        # excluded so peer scores can fill them.
         all_scored_hotkeys = list(dict.fromkeys(scored_hotkeys))  # deduplicated, ordered
 
         if self.platform_client:
@@ -989,11 +1044,11 @@ class Validator:
                 # --- Step 3: Feed backfill into ScoreTracker ---
                 for entry in backfill_scores:
                     hk = entry.get("miner_hotkey")
-                    combined_final = entry.get("combined_final")
+                    combined_final = _valid_round_score(
+                        entry.get("combined_final"),
+                        label=f"backfill score for {hk[:16] if hk else '?'}...",
+                    )
                     if combined_final is None:
-                        bt.logging.warning(
-                            f"Skipping backfill for {hk[:16] if hk else '?'}...: missing AdvancedScorer combined_final"
-                        )
                         continue
                     if hk and hk not in set(all_scored_hotkeys):
                         self.score_tracker.update(hk, combined_final)
@@ -1037,8 +1092,17 @@ class Validator:
                 return False
 
         # --- Step 4: Record round with COMPLETE hotkey set ---
-        # This must happen after backfill so decay is only applied to miners
-        # with genuinely no score this round (not just ones we didn't cover).
+        # This must happen after backfill so only miners with a valid local or
+        # peer score participate in this round's ranking.
+        if not all_scored_hotkeys:
+            self.score_tracker.ema_scores.clear()
+            self.score_tracker.last_raw_scores.clear()
+            bt.logging.error(
+                f"Round {round_id}: no valid local or backfill scores; "
+                "skipping weight submission to avoid reusing stale round scores"
+            )
+            return False
+
         if all_scored_hotkeys:
             self.score_tracker.record_round(round_id, all_scored_hotkeys)
             bt.logging.info(
@@ -1047,7 +1111,12 @@ class Validator:
             )
 
         # --- Step 5: Set chain weights ---
-        await self._set_weights_after_round(round_id, submission_times)
+        weights_finalized = await self._set_weights_after_round(round_id, submission_times)
+        if not weights_finalized:
+            bt.logging.error(
+                f"Round {round_id}: weight finalization failed; round will be retried"
+            )
+            return False
         print(f"\n   Round {round_id} scoring complete", flush=True)
         return True
 
@@ -1165,38 +1234,24 @@ class Validator:
 
         try:
             if metrics is None:
-                # Failed run - submit zeros
-                result = await self.platform_client.submit_score(
-                    round_id=round_id,
-                    miner_hotkey=miner_hotkey,
-                    snp_f1=0.0,
-                    snp_precision=0.0,
-                    snp_recall=0.0,
-                    snp_tp=0,
-                    snp_fp=0,
-                    snp_fn=0,
-                    indel_f1=0.0,
-                    indel_precision=0.0,
-                    indel_recall=0.0,
-                    indel_tp=0,
-                    indel_fp=0,
-                    indel_fn=0,
-                    additional_metrics={
-                        "scorer": "Advanced",
-                        "score_schema_version": "0.1.1",
-                        "scoring_status": "failed",
-                        "advanced_score": 0.0,
-                        "combined_final": 0.0,
-                        "snp_final": 0.0,
-                        "indel_final": 0.0,
-                        "weighted_f1": 0.0,
-                        "overcall_penalty": 0.0,
-                    },
-                    validation_runtime_seconds=validation_runtime
+                bt.logging.warning(
+                    f"No score submitted for {miner_hotkey[:16]}: metrics missing"
                 )
+                return None
             else:
                 advanced_score = AdvancedScorer.compute_advanced_score(metrics)
-                combined_final = advanced_score / 100.0
+                combined_final = _valid_round_score(
+                    advanced_score / 100.0,
+                    label=f"platform submission for {miner_hotkey[:16]}...",
+                )
+                if combined_final is None:
+                    return None
+                if _is_zero_input_advanced_fingerprint(metrics, combined_final):
+                    bt.logging.warning(
+                        f"No score submitted for {miner_hotkey[:16]}: "
+                        "AdvancedScorer all-zero-input fingerprint"
+                    )
+                    return None
                 snp_final = metrics.get("f1_snp", 0.0)
                 indel_final = metrics.get("f1_indel", 0.0)
 
@@ -1239,7 +1294,7 @@ class Validator:
                 bt.logging.warning(f"Failed to submit score for {miner_hotkey[:16]}: {e}")
             return None
 
-    async def _set_weights_after_round(self, round_id: str, submission_times: dict = None):
+    async def _set_weights_after_round(self, round_id: str, submission_times: dict = None) -> bool:
         """Compute weight distribution, set on chain (if registered), and POST history to platform.
 
         Platform submission happens regardless of chain registration so the
@@ -1248,11 +1303,11 @@ class Validator:
         registration.
         """
         try:
-            # Compute weights over the miners we've actually scored.
+            # Compute weights over the miners finalized for this round.
             tracked_miners = list(self.score_tracker.ema_scores.keys())
             if not tracked_miners:
                 bt.logging.info("No miners scored — skipping weight assignment")
-                return
+                return False
 
             # Network reward params are authoritative. If the platform cannot
             # provide a complete policy, fail closed instead of silently using
@@ -1270,20 +1325,20 @@ class Validator:
                     "Network reward config unavailable — skipping weight "
                     "submission to avoid stale reward policy"
                 )
-                return
+                return False
             if not isinstance(network_cfg, dict):
                 bt.logging.error(
                     f"Network reward config has invalid shape: {network_cfg!r} — "
                     "skipping weight submission"
                 )
-                return
+                return False
             missing_policy_fields = sorted(required_policy_fields - set(network_cfg))
             if missing_policy_fields:
                 bt.logging.error(
                     "Network reward config missing required fields "
                     f"{missing_policy_fields} — skipping weight submission"
                 )
-                return
+                return False
             try:
                 burn_rate = float(network_cfg["burn_rate"])
                 burn_uid = int(network_cfg["burn_uid"])
@@ -1307,50 +1362,50 @@ class Validator:
                     f"Invalid network reward config {network_cfg}: {exc} — "
                     "skipping weight submission"
                 )
-                return
+                return False
             miner_budget = 1.0 - burn_rate
             if not 0.0 <= burn_rate <= 1.0:
                 bt.logging.error(f"Invalid burn_rate={burn_rate} — skipping weight submission")
-                return
+                return False
             if burn_uid < 0:
                 bt.logging.error(f"Invalid burn_uid={burn_uid} — skipping weight submission")
-                return
+                return False
             if not 0.0 <= winner_weight <= miner_budget:
                 bt.logging.error(
                     f"Invalid winner_weight={winner_weight} for "
                     f"miner_budget={miner_budget} — skipping weight submission"
                 )
-                return
+                return False
             if dust_top_n < 1:
                 bt.logging.error(f"Invalid dust_top_n={dust_top_n} — skipping weight submission")
-                return
+                return False
             if dust_decay < 0.0:
                 bt.logging.error(f"Invalid dust_decay={dust_decay} — skipping weight submission")
-                return
+                return False
             if canonical_min_validator_count < 1:
                 bt.logging.error(
                     f"Invalid canonical_min_validator_count={canonical_min_validator_count} "
                     "— skipping weight submission"
                 )
-                return
+                return False
             if canonical_min_validator_stake < 0.0:
                 bt.logging.error(
                     f"Invalid canonical_min_validator_stake={canonical_min_validator_stake} "
                     "— skipping weight submission"
                 )
-                return
+                return False
 
             if len(self.metagraph.hotkeys) <= burn_uid:
                 bt.logging.error(
                     f"Burn UID {burn_uid} unavailable in metagraph — skipping "
                     "weight submission to avoid renormalizing miner weights"
                 )
-                return
+                return False
 
             burn_hotkey = self.metagraph.hotkeys[burn_uid]
 
             # Build current chain recipient map before ranking. ScoreTracker can
-            # retain EMA for hotkeys that have since deregistered or become
+            # contain current-round hotkeys that have since deregistered or become
             # validators; those must not be eligible for winner/dust selection.
             # Burn hotkey is always included so any unallocated remainder can be
             # submitted explicitly instead of relying on SDK normalization.
@@ -1385,7 +1440,7 @@ class Validator:
                 sample = ", ".join(hk[:16] for hk in positive_dropped[:5])
                 bt.logging.warning(
                     f"Excluding {len(positive_dropped)} tracked hotkey(s) from "
-                    f"weight ranking because they are not current chain miner "
+                    f"round ranking because they are not current chain miner "
                     f"recipients (sample: {sample})"
                 )
 
@@ -1470,7 +1525,7 @@ class Validator:
                         "skipping weight submission. Check "
                         "/scoring/canonical-ranking."
                     )
-                    return
+                    return False
                 elif canonical_low_coverage:
                     bt.logging.error(
                         f"Canonical ranking has insufficient coverage for "
@@ -1483,7 +1538,7 @@ class Validator:
                         f"{canonical_min_validator_stake} TAO each). Skipping "
                         "weight submission to avoid validator divergence."
                     )
-                    return
+                    return False
                 elif canonical_ranking:
                     bt.logging.info(
                         f"Canonical ranking top={canonical_ranking[0][:16]}... "
@@ -1505,14 +1560,14 @@ class Validator:
                             "candidate — skipping weight submission to avoid "
                             "local-only winner selection."
                         )
-                        return
+                        return False
                 else:
                     bt.logging.error(
                         f"Canonical ranking unavailable for round "
                         f"{round_id} — skipping weight submission to avoid "
                         "validator divergence"
                     )
-                    return
+                    return False
 
             weights = self.score_tracker.get_winner_heavy_pruning_dust_weights(
                 chain_eligible_tracked_miners,
@@ -1535,16 +1590,14 @@ class Validator:
             # Log weight distribution (mode-aware)
             stats = self.score_tracker.get_stats()
             recipients = [hk for hk, w in weights.items() if w > 0]
-            is_warmup = stats['eligible_count'] == 0
-            mode_label = "warmup split" if is_warmup else "winner-heavy + pruning dust"
+            mode_label = "round-only winner-heavy + pruning dust"
             print(f"\n   Weight distribution ({mode_label}):", flush=True)
-            print(f"   Eligible: {stats['eligible_count']}/{len(tracked_miners)} miners "
-                  f"(need {stats['min_rounds_required']} rounds)", flush=True)
+            print(f"   Eligible current-round miners: {stats['eligible_count']}/{len(tracked_miners)}", flush=True)
             if recipients:
                 for r_hk in recipients:
                     r_w = weights[r_hk]
-                    r_ema = self.score_tracker.ema_scores.get(r_hk, 0)
-                    print(f"   {r_hk[:16]}... EMA={r_ema:.4f} weight={r_w:.6f}", flush=True)
+                    r_score = self.score_tracker.ema_scores.get(r_hk, 0)
+                    print(f"   {r_hk[:16]}... score={r_score:.4f} weight={r_w:.6f}", flush=True)
             else:
                 print(f"   No recipients — weights submission skipped (fail-closed)", flush=True)
 
@@ -1561,18 +1614,19 @@ class Validator:
                 )
                 bt.logging.info(f"Weight history submitted to platform for round {round_id}")
             except Exception as e:
-                bt.logging.warning(f"Failed to POST weight history: {e}")
+                bt.logging.error(f"Failed to POST weight history: {e}")
+                return False
 
             # Set weights on chain — only if this validator is registered. Skip in
             # preprod/demo mode but still keep the platform submission above.
             if not self.is_registered:
                 bt.logging.info("Skipping on-chain set_weights — not registered (demo mode)")
-                return
+                return True
 
             chain_weights = {hk: w for hk, w in weights.items() if hk in hotkey_to_uid}
             if not chain_weights:
                 bt.logging.warning("No tracked miners on chain — skipping chain set_weights")
-                return
+                return False
 
             chain_total = sum(chain_weights.values())
             missing_weight = 1.0 - chain_total
@@ -1589,14 +1643,24 @@ class Validator:
                     f"Chain weight vector exceeds 1.0 by {-missing_weight:.8f} "
                     "— skipping weight submission"
                 )
-                return
+                return False
 
             loop = asyncio.get_running_loop()
-            await loop.run_in_executor(None, self.set_weights, chain_weights, hotkey_to_uid)
+            chain_success = await loop.run_in_executor(
+                None,
+                self.set_weights,
+                chain_weights,
+                hotkey_to_uid,
+            )
+            if not chain_success:
+                bt.logging.error(f"Round {round_id}: chain set_weights failed")
+                return False
+            return True
 
         except Exception as e:
             bt.logging.error(f"Error in _set_weights_after_round: {e}")
             bt.logging.error(traceback.format_exc())
+            return False
 
     def set_weights(self, weights_by_hotkey: dict = None, hotkey_to_uid: dict = None, retry_count: int = 0):
         """Set weights on the blockchain.
@@ -1648,12 +1712,12 @@ class Validator:
             total = sum(miner_weights)
             if total <= 0:
                 # Fail closed — never silently distribute equal weights.
-                # Zero-sum weights indicate a scoring failure or no eligible miners
-                # with positive EMA. Submitting equal weights would leak emissions.
+                # Zero-sum weights indicate a scoring failure or no current-round
+                # miners with positive scores. Submitting equal weights would leak emissions.
                 bt.logging.error(
                     "WEIGHT SAFETY: all computed weights are zero — skipping "
                     "weight submission to prevent unintended equal distribution. "
-                    "This may indicate a scoring failure or all miners having zero EMA."
+                    "This may indicate a scoring failure or all miners having zero round scores."
                 )
                 return False
             if abs(total - 1.0) > 1e-6:
@@ -1818,7 +1882,8 @@ class Validator:
                 print(f"   Platform connection error: {e} - falling back to standalone mode", flush=True)
                 self.use_platform = False
 
-        # Restart recovery: rebuild ScoreTracker from platform DB
+        # Restart recovery: platform may return legacy EMA/history payloads,
+        # but the round-only tracker starts fresh by design.
         if self.use_platform and self.platform_client:
             try:
                 print(f"   Recovering state from platform...", flush=True)
@@ -1831,8 +1896,7 @@ class Validator:
                 self.scored_rounds = set(state.get("scored_round_ids", []))
 
                 print(
-                    f"   State recovered: {len(self.score_tracker.ema_scores)} miners, "
-                    f"{len(self.scored_rounds)} scored rounds",
+                    f"   State recovered: {len(self.scored_rounds)} scored rounds",
                     flush=True,
                 )
             except Exception as e:
@@ -1854,8 +1918,8 @@ class Validator:
 
                     if step % VALIDATOR_CONFIG["scoring_interval"] == 0:
                         stats = self.score_tracker.get_stats()
-                        bt.logging.info(f"Performance stats - Top EMA: {stats['top_ema']:.4f}, "
-                                       f"Eligible: {stats['eligible_count']}/{stats['total_miners_tracked']}, "
+                        bt.logging.info(f"Performance stats - Top round score: {stats['top_round_score']:.4f}, "
+                                       f"Eligible current-round miners: {stats['eligible_count']}/{stats['total_miners_tracked']}, "
                                        f"Rounds tracked: {stats['rounds_tracked']}")
 
                     # Sync metagraph every round to catch new/removed miners quickly

--- a/scripts/auto_update.sh
+++ b/scripts/auto_update.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Minos automatic git updater.
+#
+# This is started by ./enable_auto_update.sh under PM2 as "minos-auto-update".
+# It checks the configured git branch, pulls only safe fast-forward updates,
+# and restarts only the confirmed miner/validator PM2 process.
+#
+# Safety rules:
+#   - Local git changes mean "skip update".
+#   - Non-fast-forward branch changes mean "skip update".
+#   - A missing PM2 process means "skip update".
+#   - No git reset, no force pull, no overwriting user edits.
+
+set -euo pipefail
+
+CONFIG_FILE="${MINOS_AUTO_UPDATE_CONFIG:-${HOME}/.minos/auto_update.env}"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "Auto-update config not found: ${CONFIG_FILE}"
+  echo "Run ./enable_auto_update.sh from your Minos repo first."
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$CONFIG_FILE"
+
+REPO="${MINOS_AUTO_UPDATE_REPO:?Missing MINOS_AUTO_UPDATE_REPO}"
+REMOTE="${MINOS_AUTO_UPDATE_REMOTE:-origin}"
+BRANCH="${MINOS_AUTO_UPDATE_BRANCH:-main}"
+PM2_PROCESS="${MINOS_AUTO_UPDATE_PM2_PROCESS:?Missing MINOS_AUTO_UPDATE_PM2_PROCESS}"
+INTERVAL_SECONDS="${MINOS_AUTO_UPDATE_INTERVAL_SECONDS:-300}"
+ALLOW_DIRTY="${MINOS_AUTO_UPDATE_ALLOW_DIRTY:-0}"
+LOG_FILE="${MINOS_AUTO_UPDATE_LOG:-${HOME}/.minos/auto_update.log}"
+LOCK_DIR="${HOME}/.minos/auto_update.lock"
+ACTIVE_LOCK="${MINOS_AUTO_UPDATE_ACTIVE_LOCK:-}"
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+log() {
+  printf '[%s] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*" | tee -a "$LOG_FILE"
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    log "Missing required command: $1"
+    return 1
+  fi
+}
+
+with_lock() {
+  if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    log "Another auto-update check is already running. Skipping."
+    return 0
+  fi
+  trap 'rm -rf "$LOCK_DIR"' RETURN
+  check_once
+}
+
+repo_is_dirty() {
+  [[ -n "$(git status --porcelain)" ]]
+}
+
+check_once() {
+  require_command git || return 0
+  require_command pm2 || return 0
+
+  if [[ ! -d "$REPO/.git" ]]; then
+    log "Repo not found or not a git checkout: $REPO"
+    return 0
+  fi
+
+  cd "$REPO"
+
+  current_branch="$(git branch --show-current)"
+  if [[ "$current_branch" != "$BRANCH" ]]; then
+    log "Current git branch is '${current_branch:-detached}', expected '${BRANCH}'. Skipping auto-update."
+    return 0
+  fi
+
+  if ! pm2 describe "$PM2_PROCESS" >/dev/null 2>&1; then
+    log "PM2 process '$PM2_PROCESS' not found. Run ./enable_auto_update.sh again if it was renamed."
+    return 0
+  fi
+
+  if [[ -n "$ACTIVE_LOCK" && -e "$ACTIVE_LOCK" ]]; then
+    log "Active work lock exists ($ACTIVE_LOCK). Skipping update."
+    return 0
+  fi
+
+  if repo_is_dirty && [[ "$ALLOW_DIRTY" != "1" ]]; then
+    log "Local git changes detected. Skipping auto-update to protect user edits."
+    return 0
+  fi
+
+  if ! git fetch --quiet "$REMOTE" "$BRANCH"; then
+    log "git fetch failed for ${REMOTE}/${BRANCH}."
+    return 0
+  fi
+
+  local_sha="$(git rev-parse HEAD)"
+  remote_sha="$(git rev-parse "${REMOTE}/${BRANCH}")"
+
+  if [[ "$local_sha" == "$remote_sha" ]]; then
+    log "Already up to date on ${BRANCH} (${local_sha:0:8})."
+    return 0
+  fi
+
+  if ! git merge-base --is-ancestor HEAD "${REMOTE}/${BRANCH}"; then
+    log "Remote branch is not a fast-forward from local HEAD. Manual update required."
+    return 0
+  fi
+
+  log "Update available: ${local_sha:0:8} -> ${remote_sha:0:8}. Pulling ${REMOTE}/${BRANCH}."
+
+  if ! git pull --ff-only "$REMOTE" "$BRANCH"; then
+    log "git pull --ff-only failed. PM2 process was not restarted."
+    return 0
+  fi
+
+  log "Restarting PM2 process: ${PM2_PROCESS}"
+  if pm2 restart "$PM2_PROCESS" --update-env; then
+    pm2 save >/dev/null 2>&1 || true
+    log "Update applied and '${PM2_PROCESS}' restarted."
+  else
+    log "Update pulled, but PM2 restart failed for '${PM2_PROCESS}'. Check pm2 logs."
+  fi
+}
+
+if [[ "${1:-}" == "--once" ]]; then
+  with_lock
+  exit 0
+fi
+
+log "Minos auto-update started for '${PM2_PROCESS}' on ${REMOTE}/${BRANCH}."
+while true; do
+  with_lock
+  sleep "$INTERVAL_SECONDS"
+done

--- a/tests/test_validator_finalization.py
+++ b/tests/test_validator_finalization.py
@@ -1,0 +1,84 @@
+"""Regression tests for validator round finalization."""
+
+import asyncio
+import importlib
+import sys
+import types
+
+
+def _noop(*args, **kwargs):
+    return None
+
+
+def _import_validator_with_runtime_stubs(monkeypatch):
+    """Import neurons.validator without requiring a live Bittensor runtime."""
+    logging_stub = types.SimpleNamespace(
+        debug=_noop,
+        error=_noop,
+        info=_noop,
+        warning=_noop,
+        set_debug=_noop,
+        set_trace=_noop,
+    )
+    bittensor_stub = types.SimpleNamespace(
+        Config=object,
+        Subtensor=object,
+        Wallet=object,
+        config=lambda parser=None: types.SimpleNamespace(),
+        logging=logging_stub,
+        subtensor=object,
+        wallet=object,
+    )
+    httpx_stub = types.SimpleNamespace(
+        AsyncClient=object,
+        TimeoutException=Exception,
+        ConnectError=Exception,
+        ReadError=Exception,
+    )
+
+    monkeypatch.setitem(sys.modules, "bittensor", bittensor_stub)
+    monkeypatch.setitem(sys.modules, "bittensor_wallet", types.SimpleNamespace(Keypair=object))
+    monkeypatch.setitem(sys.modules, "dotenv", types.SimpleNamespace(load_dotenv=_noop))
+    monkeypatch.setitem(sys.modules, "httpx", httpx_stub)
+    monkeypatch.setitem(sys.modules, "numpy", types.SimpleNamespace())
+    sys.modules.pop("neurons.validator", None)
+    return importlib.import_module("neurons.validator")
+
+
+def test_finalize_round_with_no_valid_scores_does_not_reuse_previous_round(monkeypatch):
+    validator_module = _import_validator_with_runtime_stubs(monkeypatch)
+    tracker = validator_module.ScoreTracker()
+
+    tracker.update("hk_previous", 0.91)
+    tracker.record_round("round_previous", ["hk_previous"])
+    assert tracker.ema_scores == {"hk_previous": 0.91}
+
+    set_weights_called = False
+
+    async def set_weights_after_round(*args, **kwargs):
+        nonlocal set_weights_called
+        set_weights_called = True
+        return True
+
+    validator = types.SimpleNamespace(
+        platform_client=None,
+        score_tracker=tracker,
+        _set_weights_after_round=set_weights_after_round,
+    )
+
+    result = asyncio.run(
+        validator_module.Validator._finalize_round_scores(
+            validator,
+            round_id="round_without_scores",
+            scored_hotkeys=[],
+            submission_times={},
+            scoring_deadline=None,
+        )
+    )
+
+    assert result is False
+    assert not set_weights_called
+    assert tracker.ema_scores == {}
+    assert tracker.last_raw_scores == {}
+
+    sys.modules.pop("neurons.validator", None)

--- a/tests/test_weight_tracking.py
+++ b/tests/test_weight_tracking.py
@@ -1,73 +1,17 @@
-"""Comprehensive tests for utils.weight_tracking.ScoreTracker."""
+"""Tests for round-only winner weighting."""
 
 import pytest
 
 from utils.weight_tracking import (
     ScoreTracker,
-    PARTICIPATION_WINDOW,
-    WARMUP_WEIGHTS,
-    SCORE_EPSILON,
     DEFAULT_BURN_RATE,
     DEFAULT_WINNER_WEIGHT,
     DEFAULT_DUST_TOP_N,
     DEFAULT_DUST_DECAY,
     CANONICAL_TIEBREAK_TOLERANCE,
+    MIN_PARTICIPATION_ROUNDS,
+    PARTICIPATION_WINDOW,
 )
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _make_eligible(tracker: ScoreTracker, hotkey: str, score: float = 0.80):
-    """Shortcut: update + record enough rounds to make *hotkey* eligible.
-
-    WARNING: calling this for multiple hotkeys on the same tracker causes
-    decay and window-trim side-effects. Use _make_eligible_group instead.
-    """
-    for i in range(tracker.min_rounds):
-        tracker.update(hotkey, score)
-        tracker.record_round(f"elig-{hotkey}-{i}", [hotkey])
-
-
-def _make_eligible_group(
-    tracker: ScoreTracker,
-    hotkey_scores: dict,
-):
-    """Make several miners eligible in the *same* rounds (avoids cross-decay).
-
-    Args:
-        hotkey_scores: {hotkey: raw_score, ...}
-    """
-    hotkeys = list(hotkey_scores.keys())
-    for i in range(tracker.min_rounds):
-        for hk, score in hotkey_scores.items():
-            tracker.update(hk, score)
-        tracker.record_round(f"elig-group-{i}", hotkeys)
-
-
-def _make_active(tracker: ScoreTracker, hotkey: str, rounds: int = 1,
-                 score: float = 0.80):
-    """Record *rounds* rounds for *hotkey* (not necessarily eligible)."""
-    for i in range(rounds):
-        tracker.update(hotkey, score)
-        tracker.record_round(f"active-{hotkey}-{i}", [hotkey])
-
-
-def _seed_eligible_emas(tracker: ScoreTracker, hotkey_emas: dict):
-    """Seed exact EMA values and eligibility for tolerance-boundary tests."""
-    hotkeys = list(hotkey_emas.keys())
-    for hk, ema in hotkey_emas.items():
-        tracker.ema_scores[hk] = ema
-
-    # Add participation history without changing the seeded EMA values.
-    for i in range(tracker.min_rounds):
-        tracker.round_history.append({
-            "round_id": f"seed-{i}",
-            "scored_hotkeys": list(hotkeys),
-            "active_hotkeys": list(hotkeys),
-        })
-    tracker._recalculate_participation()
 
 
 DEFAULT_REWARD_POLICY = {
@@ -78,189 +22,125 @@ DEFAULT_REWARD_POLICY = {
 }
 
 
-# =========================================================================
-# TestScoreTrackerInit
-# =========================================================================
-
-class TestScoreTrackerInit:
-    """Verify constructor defaults and env-var overrides."""
-
-    def test_default_values(self):
-        tracker = ScoreTracker(alpha=0.1, decay_factor=0.95)
-        assert tracker.alpha == 0.1
-        assert tracker.decay_factor == 0.95
-        assert tracker.min_rounds == 10  # module-level default
-
-    def test_custom_values(self):
-        tracker = ScoreTracker(alpha=0.25, min_rounds=5, decay_factor=0.90)
-        assert tracker.alpha == 0.25
-        assert tracker.min_rounds == 5
-        assert tracker.decay_factor == 0.90
-
-    def test_env_var_override(self, monkeypatch):
-        monkeypatch.setenv("EMA_ALPHA", "0.42")
-        monkeypatch.setenv("EMA_DECAY_FACTOR", "0.88")
-        tracker = ScoreTracker(alpha=None, decay_factor=None)
-        assert tracker.alpha == pytest.approx(0.42)
-        assert tracker.decay_factor == pytest.approx(0.88)
+def _record_scores(tracker: ScoreTracker, round_id: str, scores: dict):
+    for hotkey, score in scores.items():
+        tracker.update(hotkey, score)
+    tracker.record_round(round_id, list(scores))
 
 
-# =========================================================================
-# TestUpdate
-# =========================================================================
-
-class TestUpdate:
-    """EMA update semantics."""
-
-    def test_first_update_from_zero(self, score_tracker):
-        """First update: EMA starts at 0, so new = alpha * score."""
-        ema = score_tracker.update("hk_a", 1.0)
-        assert ema == pytest.approx(0.1 * 1.0)
-
-    def test_second_update(self, score_tracker):
-        """Second update applies the full EMA formula."""
-        score_tracker.update("hk_a", 1.0)
-        ema2 = score_tracker.update("hk_a", 0.5)
-        expected = (1 - 0.1) * 0.1 + 0.1 * 0.5  # 0.09 + 0.05 = 0.14
-        assert ema2 == pytest.approx(expected)
-
-    def test_converges_toward_repeated_score(self, score_tracker):
-        """Repeated identical scores should make EMA converge to that value."""
-        for _ in range(200):
-            ema = score_tracker.update("hk_a", 0.75)
-        assert ema == pytest.approx(0.75, abs=1e-4)
-
-    def test_score_of_zero_decays_ema(self, score_tracker):
-        """Feeding score=0 should shrink the EMA toward 0."""
-        score_tracker.update("hk_a", 1.0)  # EMA = 0.1
-        ema = score_tracker.update("hk_a", 0.0)
-        assert ema == pytest.approx(0.9 * 0.1)
-        assert ema < 0.1
-
-    def test_last_raw_scores_set(self, score_tracker):
-        """update() must record the raw score for reporting."""
-        score_tracker.update("hk_a", 0.77)
-        assert score_tracker.last_raw_scores["hk_a"] == pytest.approx(0.77)
-        score_tracker.update("hk_a", 0.55)
-        assert score_tracker.last_raw_scores["hk_a"] == pytest.approx(0.55)
+def _seed_participation(tracker: ScoreTracker, hotkeys, count: int):
+    tracker.recover_from_platform_state(
+        [],
+        [
+            {"round_id": f"seed_{idx}", "scored_hotkeys": list(hotkeys)}
+            for idx in range(count)
+        ],
+    )
 
 
-# =========================================================================
-# TestRecordRound
-# =========================================================================
+class TestRoundOnlyState:
+    def test_update_records_latest_round_score_without_smoothing(self, score_tracker):
+        assert score_tracker.update("hk_a", 1.0) == pytest.approx(1.0)
+        assert score_tracker.update("hk_a", 0.5) == pytest.approx(0.5)
+        assert score_tracker.ema_scores["hk_a"] == pytest.approx(0.5)
+        assert score_tracker.last_raw_scores["hk_a"] == pytest.approx(0.5)
 
-class TestRecordRound:
-    """Round recording, decay, dedup, and window trimming."""
+    def test_update_rejects_invalid_round_scores(self, score_tracker):
+        for bad_score in (None, "nan", -0.1, 0.0, 1.1):
+            with pytest.raises(ValueError):
+                score_tracker.update("hk_bad", bad_score)
+        assert "hk_bad" not in score_tracker.ema_scores
 
-    def test_single_round_participation(self, score_tracker):
-        score_tracker.update("hk_a", 0.5)
-        score_tracker.record_round("r1", ["hk_a"])
-        assert score_tracker.get_participation_count("hk_a") == 1
+    def test_nine_of_twenty_is_not_eligible(self, score_tracker):
+        _seed_participation(score_tracker, ["hk_a"], MIN_PARTICIPATION_ROUNDS - 1)
 
-    def test_duplicate_round_is_idempotent(self, score_tracker):
-        score_tracker.update("hk_a", 0.5)
-        score_tracker.record_round("r1", ["hk_a"])
-        score_tracker.record_round("r1", ["hk_a"])  # same id
-        assert score_tracker.get_participation_count("hk_a") == 1
-        assert len(score_tracker.round_history) == 1
-
-    def test_decay_applied_to_absent_miners(self, score_tracker):
-        score_tracker.update("hk_a", 1.0)  # EMA = 0.1
-        score_tracker.update("hk_b", 1.0)  # EMA = 0.1
-        # Only hk_a scored in this round → hk_b should decay
-        score_tracker.record_round("r1", ["hk_a"])
-        assert score_tracker.ema_scores["hk_b"] == pytest.approx(0.1 * 0.95)
-        # hk_a should be unchanged
-        assert score_tracker.ema_scores["hk_a"] == pytest.approx(0.1)
-
-    def test_miner_removed_when_ema_below_threshold(self, score_tracker):
-        """Miners whose EMA decays below 1e-6 get pruned."""
-        score_tracker.ema_scores["hk_ghost"] = 1e-6  # just at boundary
-        score_tracker.record_round("r1", [])  # hk_ghost absent
-        assert "hk_ghost" not in score_tracker.ema_scores
-
-    def test_window_trimming_at_21_rounds(self, score_tracker):
-        """After 21 rounds, only the last 20 should remain."""
-        for i in range(21):
-            score_tracker.update("hk_a", 0.5)
-            score_tracker.record_round(f"r{i}", ["hk_a"])
-        assert len(score_tracker.round_history) == PARTICIPATION_WINDOW
-
-    def test_participation_recalculated_after_trim(self, score_tracker):
-        """Miner present only in the oldest round loses that count after trim."""
-        # hk_b scored only in round 0
-        score_tracker.update("hk_b", 0.5)
-        score_tracker.update("hk_a", 0.5)
-        score_tracker.record_round("r0", ["hk_a", "hk_b"])
-        # Rounds 1..20 only have hk_a
-        for i in range(1, 21):
-            score_tracker.update("hk_a", 0.5)
-            score_tracker.record_round(f"r{i}", ["hk_a"])
-        # r0 has been trimmed; hk_b should have 0 participation
-        assert score_tracker.get_participation_count("hk_b") == 0
-        assert score_tracker.get_participation_count("hk_a") == PARTICIPATION_WINDOW
-
-    def test_decay_factor_one_means_no_decay(self):
-        tracker = ScoreTracker(alpha=0.1, min_rounds=10, decay_factor=1.0)
-        tracker.update("hk_a", 1.0)  # EMA = 0.1
-        tracker.record_round("r1", [])  # hk_a absent
-        assert tracker.ema_scores["hk_a"] == pytest.approx(0.1)
-
-    def test_empty_scored_hotkeys_decays_all(self, score_tracker):
-        score_tracker.update("hk_a", 1.0)
-        score_tracker.update("hk_b", 1.0)
-        score_tracker.record_round("r1", [])
-        assert score_tracker.ema_scores["hk_a"] == pytest.approx(0.1 * 0.95)
-        assert score_tracker.ema_scores["hk_b"] == pytest.approx(0.1 * 0.95)
-
-
-# =========================================================================
-# TestEligibility
-# =========================================================================
-
-class TestEligibility:
-    """Participation-based eligibility gating (min_rounds=10)."""
-
-    def test_below_threshold(self, score_tracker):
-        for i in range(9):
-            score_tracker.update("hk_a", 0.5)
-            score_tracker.record_round(f"r{i}", ["hk_a"])
+        assert score_tracker.get_participation_count("hk_a") == MIN_PARTICIPATION_ROUNDS - 1
         assert not score_tracker.is_eligible("hk_a")
 
-    def test_at_threshold(self, score_tracker):
-        for i in range(10):
-            score_tracker.update("hk_a", 0.5)
-            score_tracker.record_round(f"r{i}", ["hk_a"])
+    def test_ten_of_twenty_is_eligible(self, score_tracker):
+        _seed_participation(score_tracker, ["hk_a"], MIN_PARTICIPATION_ROUNDS)
+
+        assert score_tracker.get_participation_count("hk_a") == MIN_PARTICIPATION_ROUNDS
         assert score_tracker.is_eligible("hk_a")
 
-    def test_above_threshold(self, score_tracker):
-        for i in range(15):
-            score_tracker.update("hk_a", 0.5)
-            score_tracker.record_round(f"r{i}", ["hk_a"])
-        assert score_tracker.is_eligible("hk_a")
+    def test_window_slide_can_drop_eligibility(self, score_tracker):
+        round_history = [
+            {
+                "round_id": f"round_{idx}",
+                "scored_hotkeys": ["hk_a"] if idx < MIN_PARTICIPATION_ROUNDS else ["hk_b"],
+            }
+            for idx in range(PARTICIPATION_WINDOW + 1)
+        ]
 
-    def test_unknown_hotkey(self, score_tracker):
+        score_tracker.recover_from_platform_state([], round_history)
+
+        assert score_tracker.get_participation_count("hk_a") == MIN_PARTICIPATION_ROUNDS - 1
+        assert not score_tracker.is_eligible("hk_a")
+
+    def test_current_round_counts_toward_window_eligibility(self, score_tracker):
+        _seed_participation(score_tracker, ["hk_a"], MIN_PARTICIPATION_ROUNDS - 1)
+        _record_scores(score_tracker, "r1", {"hk_a": 0.9, "hk_b": 0.7})
+
+        assert score_tracker.is_eligible("hk_a")
+        assert not score_tracker.is_eligible("hk_b")
+        assert score_tracker.get_participation_count("hk_a") == MIN_PARTICIPATION_ROUNDS
+        assert score_tracker.get_participation_count("hk_b") == 1
         assert score_tracker.get_participation_count("hk_unknown") == 0
         assert not score_tracker.is_eligible("hk_unknown")
 
+    def test_record_round_drops_stale_scores_but_keeps_recent_counts(self, score_tracker):
+        _record_scores(score_tracker, "r1", {"hk_a": 0.9, "hk_b": 0.7})
+        _record_scores(score_tracker, "r2", {"hk_b": 0.8, "hk_c": 0.6})
 
-# =========================================================================
-# TestWinnerHeavyPruningDust
-# =========================================================================
+        assert set(score_tracker.ema_scores) == {"hk_b", "hk_c"}
+        assert score_tracker.get_participation_count("hk_a") == 1
+        assert score_tracker.get_participation_count("hk_b") == 2
 
-class TestWinnerHeavyPruningDust:
-    """Production normal mode: winner-heavy with pruning dust for top ranks."""
+    def test_recovery_ignores_historical_scores_but_loads_recent_rounds(self, score_tracker):
+        score_tracker.recover_from_platform_state(
+            [{
+                "miner_hotkey": "hk_old",
+                "ema_score": 0.99,
+                "participation_count": MIN_PARTICIPATION_ROUNDS,
+            }],
+            [
+                {"round_id": f"old_{idx}", "scored_hotkeys": ["hk_old"]}
+                for idx in range(MIN_PARTICIPATION_ROUNDS)
+            ],
+        )
 
-    def test_top_ten_distribution(self, score_tracker):
-        scores = {
-            f"hk_{i}": 1.0 - (i * 0.01)
-            for i in range(1, 12)
-        }
-        _make_eligible_group(score_tracker, scores)
+        assert score_tracker.ema_scores == {}
+        assert score_tracker.last_raw_scores == {}
+        assert len(score_tracker.round_history) == MIN_PARTICIPATION_ROUNDS
+        assert score_tracker.get_participation_count("hk_old") == MIN_PARTICIPATION_ROUNDS
+        assert score_tracker.is_eligible("hk_old")
 
-        hotkeys = list(scores.keys())
+    def test_recovery_trims_to_recent_window(self, score_tracker):
+        round_history = [
+            {
+                "round_id": f"old_{idx}",
+                "scored_hotkeys": ["hk_old"] if idx < 10 else ["hk_recent"],
+            }
+            for idx in range(PARTICIPATION_WINDOW + 5)
+        ]
+
+        score_tracker.recover_from_platform_state([], round_history)
+
+        assert len(score_tracker.round_history) == PARTICIPATION_WINDOW
+        assert score_tracker.get_participation_count("hk_old") == 5
+        assert score_tracker.get_participation_count("hk_recent") == 15
+        assert not score_tracker.is_eligible("hk_old")
+        assert score_tracker.is_eligible("hk_recent")
+
+
+class TestRoundOnlyWeights:
+    def test_top_ten_distribution_uses_current_round_scores(self, score_tracker):
+        scores = {f"hk_{i}": 1.0 - (i * 0.01) for i in range(1, 12)}
+        _seed_participation(score_tracker, scores, MIN_PARTICIPATION_ROUNDS - 1)
+        _record_scores(score_tracker, "r1", scores)
+
         weights = score_tracker.get_winner_heavy_pruning_dust_weights(
-            hotkeys, **DEFAULT_REWARD_POLICY
+            list(scores), **DEFAULT_REWARD_POLICY
         )
 
         assert weights["hk_1"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
@@ -275,42 +155,9 @@ class TestWinnerHeavyPruningDust:
 
         assert sum(weights.values()) == pytest.approx(1.0 - DEFAULT_BURN_RATE)
 
-    def test_default_top_ten_dust_survives_u16_emit_rounding(self, score_tracker):
-        scores = {
-            f"hk_{i}": 1.0 - (i * 0.01)
-            for i in range(1, 11)
-        }
-        _make_eligible_group(score_tracker, scores)
-
-        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
-            list(scores.keys()), **DEFAULT_REWARD_POLICY
-        )
-        burn_weight = 1.0 - sum(weights.values())
-        max_weight = max(burn_weight, max(weights.values()))
-
-        for rank in range(2, 11):
-            encoded = round(weights[f"hk_{rank}"] / max_weight * 65535)
-            assert encoded > 0
-
-    def test_fewer_than_ten_eligible_renormalizes_dust(self, score_tracker):
-        _make_eligible_group(
-            score_tracker,
-            {"hk_a": 0.90, "hk_b": 0.80, "hk_c": 0.70},
-        )
-
-        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
-            ["hk_a", "hk_b", "hk_c"], **DEFAULT_REWARD_POLICY
-        )
-
-        dust_pool = 1.0 - DEFAULT_BURN_RATE - DEFAULT_WINNER_WEIGHT
-        dust_total = 1.0 + DEFAULT_DUST_DECAY
-        assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
-        assert weights["hk_b"] == pytest.approx(dust_pool / dust_total)
-        assert weights["hk_c"] == pytest.approx(dust_pool * DEFAULT_DUST_DECAY / dust_total)
-        assert sum(weights.values()) == pytest.approx(1.0 - DEFAULT_BURN_RATE)
-
-    def test_single_eligible_keeps_winner_weight_only(self, score_tracker):
-        _make_eligible(score_tracker, "hk_a", score=0.90)
+    def test_single_positive_winner_keeps_winner_weight_only(self, score_tracker):
+        _seed_participation(score_tracker, ["hk_a"], MIN_PARTICIPATION_ROUNDS - 1)
+        _record_scores(score_tracker, "r1", {"hk_a": 0.9})
 
         weights = score_tracker.get_winner_heavy_pruning_dust_weights(
             ["hk_a"], **DEFAULT_REWARD_POLICY
@@ -319,334 +166,114 @@ class TestWinnerHeavyPruningDust:
         assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
         assert sum(weights.values()) == pytest.approx(DEFAULT_WINNER_WEIGHT)
 
-    def test_ineligible_high_ema_gets_zero(self, score_tracker):
-        _make_eligible(score_tracker, "hk_a", score=0.80)
-        _make_active(score_tracker, "hk_b", rounds=1, score=0.99)
+    def test_no_current_scores_return_zero_weights(self, score_tracker):
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a", "hk_b"], **DEFAULT_REWARD_POLICY
+        )
+
+        assert weights == {"hk_a": 0.0, "hk_b": 0.0}
+
+    def test_earliest_submission_breaks_exact_score_tie(self, score_tracker):
+        _seed_participation(
+            score_tracker, ["hk_a", "hk_b"], MIN_PARTICIPATION_ROUNDS - 1
+        )
+        _record_scores(score_tracker, "r1", {"hk_a": 0.9, "hk_b": 0.9})
+
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
+            ["hk_a", "hk_b"],
+            submission_times={"hk_a": 200.0, "hk_b": 100.0},
+            **DEFAULT_REWARD_POLICY,
+        )
+
+        assert weights["hk_b"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
+
+    def test_ineligible_high_score_cannot_win(self, score_tracker):
+        _seed_participation(score_tracker, ["hk_b"], MIN_PARTICIPATION_ROUNDS - 1)
+        _record_scores(score_tracker, "r1", {"hk_a": 1.0, "hk_b": 0.7})
 
         weights = score_tracker.get_winner_heavy_pruning_dust_weights(
             ["hk_a", "hk_b"], **DEFAULT_REWARD_POLICY
         )
 
-        assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
-        assert weights["hk_b"] == pytest.approx(0.0)
-
-    def test_all_eligible_zero_ema_returns_all_zero(self, score_tracker):
-        for i in range(score_tracker.min_rounds):
-            score_tracker.record_round(f"r{i}", ["hk_a", "hk_b"])
-
-        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
-            ["hk_a", "hk_b"], **DEFAULT_REWARD_POLICY
-        )
-
+        assert not score_tracker.is_eligible("hk_a")
+        assert score_tracker.is_eligible("hk_b")
         assert weights["hk_a"] == pytest.approx(0.0)
-        assert weights["hk_b"] == pytest.approx(0.0)
+        assert weights["hk_b"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
 
-    def test_warmup_scaled_to_non_burn_budget(self, score_tracker):
-        _make_active(score_tracker, "hk_a", rounds=1, score=0.90)
-        _make_active(score_tracker, "hk_b", rounds=1, score=0.70)
-
-        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
-            ["hk_a", "hk_b"], **DEFAULT_REWARD_POLICY
-        )
-
-        miner_budget = 1.0 - DEFAULT_BURN_RATE
-        assert weights["hk_a"] == pytest.approx(miner_budget * 0.5 / 0.8)
-        assert weights["hk_b"] == pytest.approx(miner_budget * 0.3 / 0.8)
-        assert sum(weights.values()) == pytest.approx(miner_budget)
-
-
-# =========================================================================
-# TestCanonicalTiebreak
-# =========================================================================
 
 class TestCanonicalTiebreak:
-    """Canonical-ranking tiebreak when local leaders are within tolerance.
-
-    The canonical ranking comes from the platform's /scoring/canonical-ranking
-    endpoint. The validator scans it for the first locally eligible candidate
-    and uses that as a tiebreaker only inside the tolerance band.
-    """
-
-    def test_canonical_not_needed_during_warmup(self, score_tracker):
-        _make_active(score_tracker, "hk_a", rounds=1, score=0.90)
-        _make_active(score_tracker, "hk_b", rounds=1, score=0.89)
-        assert not score_tracker.needs_canonical_tiebreak(["hk_a", "hk_b"])
-
-    def test_canonical_not_needed_for_clear_local_winner(self, score_tracker):
-        _seed_eligible_emas(score_tracker, {"hk_a": 0.700, "hk_b": 0.650})
-        assert not score_tracker.needs_canonical_tiebreak(["hk_a", "hk_b"])
-
-    def test_canonical_needed_for_close_local_winner(self, score_tracker):
-        _seed_eligible_emas(score_tracker, {"hk_a": 0.700, "hk_b": 0.695})
-        assert score_tracker.needs_canonical_tiebreak(["hk_a", "hk_b"])
-
-    def test_canonical_needed_at_exact_tolerance_boundary(self, score_tracker):
-        gap = CANONICAL_TIEBREAK_TOLERANCE
-        _seed_eligible_emas(
-            score_tracker, {"hk_a": 0.70, "hk_b": 0.70 - gap}
+    def test_canonical_needed_for_close_current_round_scores(self, score_tracker):
+        _seed_participation(
+            score_tracker, ["hk_a", "hk_b"], MIN_PARTICIPATION_ROUNDS - 1
         )
+        _record_scores(score_tracker, "r1", {"hk_a": 0.700, "hk_b": 0.695})
         assert score_tracker.needs_canonical_tiebreak(["hk_a", "hk_b"])
+
+    def test_canonical_not_needed_for_clear_current_round_winner(self, score_tracker):
+        _seed_participation(
+            score_tracker, ["hk_a", "hk_b"], MIN_PARTICIPATION_ROUNDS - 1
+        )
+        _record_scores(score_tracker, "r1", {"hk_a": 0.700, "hk_b": 0.650})
+        assert not score_tracker.needs_canonical_tiebreak(["hk_a", "hk_b"])
 
     def test_canonical_used_when_within_tolerance(self, score_tracker):
-        # Local rank-1 = hk_a (0.700 EMA), rank-2 = hk_b (0.695 EMA).
-        # Gap 0.5%, within 2% tolerance. Canonical says hk_b, so hk_b wins.
-        _seed_eligible_emas(score_tracker, {"hk_a": 0.700, "hk_b": 0.695})
+        _seed_participation(
+            score_tracker, ["hk_a", "hk_b"], MIN_PARTICIPATION_ROUNDS - 1
+        )
+        _record_scores(score_tracker, "r1", {"hk_a": 0.700, "hk_b": 0.695})
+
         weights = score_tracker.get_winner_heavy_pruning_dust_weights(
             ["hk_a", "hk_b"],
             canonical_top="hk_b",
             **DEFAULT_REWARD_POLICY,
         )
+
         assert weights["hk_b"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
-        dust_pool = 1.0 - DEFAULT_BURN_RATE - DEFAULT_WINNER_WEIGHT
-        assert weights["hk_a"] == pytest.approx(dust_pool)
 
     def test_canonical_ignored_when_outside_tolerance(self, score_tracker):
-        # EMA gap is outside tolerance, so local rank 1 remains the winner.
-        _seed_eligible_emas(score_tracker, {"hk_a": 0.700, "hk_b": 0.640})
-        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
-            ["hk_a", "hk_b"],
-            canonical_top="hk_b",
-            **DEFAULT_REWARD_POLICY,
+        _seed_participation(
+            score_tracker, ["hk_a", "hk_b"], MIN_PARTICIPATION_ROUNDS - 1
         )
-        assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
-        dust_pool = 1.0 - DEFAULT_BURN_RATE - DEFAULT_WINNER_WEIGHT
-        assert weights["hk_b"] == pytest.approx(dust_pool)
-
-    def test_canonical_at_exact_tolerance_boundary(self, score_tracker):
-        # Boundary is inclusive.
-        gap = CANONICAL_TIEBREAK_TOLERANCE
-        _seed_eligible_emas(
-            score_tracker, {"hk_a": 0.70, "hk_b": 0.70 - gap}
-        )
-        actual_gap = (
-            score_tracker.ema_scores["hk_a"] - score_tracker.ema_scores["hk_b"]
-        )
-        assert actual_gap == pytest.approx(CANONICAL_TIEBREAK_TOLERANCE)
-        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
-            ["hk_a", "hk_b"],
-            canonical_top="hk_b",
-            **DEFAULT_REWARD_POLICY,
-        )
-        assert weights["hk_b"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
-
-    def test_canonical_just_outside_tolerance(self, score_tracker):
-        # Just outside the tolerance band, local rank 1 remains the winner.
-        gap = CANONICAL_TIEBREAK_TOLERANCE + 0.001
-        _seed_eligible_emas(
-            score_tracker, {"hk_a": 0.70, "hk_b": 0.70 - gap}
-        )
-        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
-            ["hk_a", "hk_b"],
-            canonical_top="hk_b",
-            **DEFAULT_REWARD_POLICY,
-        )
-        assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
-
-    def test_canonical_lower_than_local_rank1_within_tolerance(self, score_tracker):
-        _seed_eligible_emas(
-            score_tracker, {"hk_a": 0.700, "hk_b": 0.715},
-        )
-        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
-            ["hk_a", "hk_b"],
-            canonical_top="hk_a",
-            **DEFAULT_REWARD_POLICY,
-        )
-        assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
-
-    def test_canonical_not_in_eligible_set_falls_back(self, score_tracker):
-        # A canonical hotkey outside local eligibility cannot be used.
-        _seed_eligible_emas(score_tracker, {"hk_a": 0.700, "hk_b": 0.695})
-        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
-            ["hk_a", "hk_b"],
-            canonical_top="hk_unknown_validator_in_some_other_subnet",
-            **DEFAULT_REWARD_POLICY,
-        )
-        assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
-
-    def test_canonical_ranking_skips_ineligible_rank1(self, score_tracker):
-        # Scan past canonical entries that are not locally eligible.
-        _seed_eligible_emas(score_tracker, {"hk_a": 0.700, "hk_b": 0.695})
-        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
-            ["hk_a", "hk_b"],
-            canonical_ranking=["hk_new_not_eligible", "hk_b", "hk_a"],
-            **DEFAULT_REWARD_POLICY,
-        )
-        assert weights["hk_b"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
-
-    def test_canonical_ranking_candidate_outside_tolerance_falls_back(self, score_tracker):
-        _seed_eligible_emas(score_tracker, {"hk_a": 0.700, "hk_b": 0.650})
-        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
-            ["hk_a", "hk_b"],
-            canonical_ranking=["hk_new_not_eligible", "hk_b"],
-            **DEFAULT_REWARD_POLICY,
-        )
-        assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
-
-    def test_canonical_ranking_scans_past_out_of_band_candidate(self, score_tracker):
-        _seed_eligible_emas(
+        _record_scores(
             score_tracker,
-            {"hk_a": 0.700, "hk_b": 0.690, "hk_c": 0.650},
+            "r1",
+            {"hk_a": 0.700, "hk_b": 0.700 - CANONICAL_TIEBREAK_TOLERANCE - 0.001},
         )
-        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
-            ["hk_a", "hk_b", "hk_c"],
-            canonical_ranking=["hk_c", "hk_b", "hk_a"],
-            **DEFAULT_REWARD_POLICY,
-        )
-        assert weights["hk_b"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
 
-    def test_no_canonical_preserves_pure_function_baseline(self, score_tracker):
-        # No canonical input preserves local EMA ranking.
-        _seed_eligible_emas(score_tracker, {"hk_a": 0.700, "hk_b": 0.695})
         weights = score_tracker.get_winner_heavy_pruning_dust_weights(
             ["hk_a", "hk_b"],
-            canonical_top=None,
-            **DEFAULT_REWARD_POLICY,
-        )
-        assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
-
-    def test_no_canonical_matches_default_call(self, score_tracker):
-        # Explicit None and omitted canonical input should be equivalent.
-        _seed_eligible_emas(
-            score_tracker,
-            {"hk_a": 0.70, "hk_b": 0.69, "hk_c": 0.68, "hk_d": 0.67},
-        )
-        with_none = score_tracker.get_winner_heavy_pruning_dust_weights(
-            ["hk_a", "hk_b", "hk_c", "hk_d"],
-            canonical_top=None,
-            **DEFAULT_REWARD_POLICY,
-        )
-        without_kwarg = score_tracker.get_winner_heavy_pruning_dust_weights(
-            ["hk_a", "hk_b", "hk_c", "hk_d"],
-            **DEFAULT_REWARD_POLICY,
-        )
-        assert with_none == without_kwarg
-
-    def test_canonical_matches_local_rank1_is_noop(self, score_tracker):
-        _seed_eligible_emas(score_tracker, {"hk_a": 0.700, "hk_b": 0.695})
-        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
-            ["hk_a", "hk_b"],
-            canonical_top="hk_a",
-            **DEFAULT_REWARD_POLICY,
-        )
-        assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
-
-    def test_dust_redistribution_after_canonical_override(self, score_tracker):
-        # Three eligible miners (all within tolerance), canonical promotes
-        # rank 2 to winner. The displaced local rank 1 keeps the top dust slot.
-        _seed_eligible_emas(
-            score_tracker,
-            {"hk_a": 0.700, "hk_b": 0.695, "hk_c": 0.690},
-        )
-        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
-            ["hk_a", "hk_b", "hk_c"],
             canonical_top="hk_b",
             **DEFAULT_REWARD_POLICY,
         )
-        assert weights["hk_b"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
-        dust_pool = 1.0 - DEFAULT_BURN_RATE - DEFAULT_WINNER_WEIGHT
-        dust_total = 1.0 + DEFAULT_DUST_DECAY
-        assert weights["hk_a"] == pytest.approx(dust_pool / dust_total)
-        assert weights["hk_c"] == pytest.approx(
-            dust_pool * DEFAULT_DUST_DECAY / dust_total
-        )
 
-    def test_canonical_with_single_eligible_miner(self, score_tracker):
-        # A single locally eligible miner remains the winner.
-        _seed_eligible_emas(score_tracker, {"hk_a": 0.90})
-        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
-            ["hk_a"],
-            canonical_top="hk_some_other",
-            **DEFAULT_REWARD_POLICY,
-        )
         assert weights["hk_a"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
 
-    def test_canonical_full_top10_dust_displaced_winner(self, score_tracker):
-        # Canonical rank 2 wins; local rank 1 remains first dust recipient.
-        emas = {f"hk_{i:02d}": 0.700 - i * 0.001 for i in range(1, 12)}
-        _seed_eligible_emas(score_tracker, emas)
-        miner_list = list(emas.keys())
-        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
-            miner_list,
-            canonical_top="hk_02",
-            **DEFAULT_REWARD_POLICY,
-        )
-        non_zero = [hk for hk, w in weights.items() if w > 0]
-        assert len(non_zero) == 10, f"expected 10 non-zero, got {len(non_zero)}"
-        assert weights["hk_02"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
-        assert weights["hk_11"] == 0
-        assert weights["hk_01"] > weights["hk_03"]
-
-
-# =========================================================================
-# TestRecoverFromPlatformState
-# =========================================================================
-
-class TestRecoverFromPlatformState:
-    """State recovery from platform DB."""
-
-    def test_empty_state(self, score_tracker):
-        score_tracker.recover_from_platform_state([], [])
-        assert score_tracker.ema_scores == {}
-        assert score_tracker.round_history == []
-
-    def test_recovery_restores_ema_and_participation(self, score_tracker):
-        ema_entries = [
-            {"miner_hotkey": "hk_a", "ema_score": 0.55, "participation_count": 5, "eligible": False},
-            {"miner_hotkey": "hk_b", "ema_score": 0.30, "participation_count": 3, "eligible": False},
-        ]
-        round_history = [
-            {"round_id": f"r{i}", "scored_hotkeys": ["hk_a"]}
-            for i in range(5)
-        ] + [
-            {"round_id": f"r{i}", "scored_hotkeys": ["hk_a", "hk_b"]}
-            for i in range(5, 8)
-        ]
-        score_tracker.recover_from_platform_state(ema_entries, round_history)
-        assert score_tracker.ema_scores["hk_a"] == pytest.approx(0.55)
-        assert score_tracker.ema_scores["hk_b"] == pytest.approx(0.30)
-        assert score_tracker.get_participation_count("hk_a") == 8
-        assert score_tracker.get_participation_count("hk_b") == 3
-
-    def test_recovery_trims_to_window(self, score_tracker):
-        """History exceeding PARTICIPATION_WINDOW gets trimmed on recovery."""
-        ema_entries = [{"miner_hotkey": "hk_a", "ema_score": 0.5}]
-        round_history = [
-            {"round_id": f"r{i}", "scored_hotkeys": ["hk_a"]}
-            for i in range(25)
-        ]
-        score_tracker.recover_from_platform_state(ema_entries, round_history)
-        assert len(score_tracker.round_history) == PARTICIPATION_WINDOW
-        # Only the last 20 rounds survive (r5..r24)
-        assert score_tracker.round_history[0]["round_id"] == "r5"
-        assert score_tracker.get_participation_count("hk_a") == PARTICIPATION_WINDOW
-
-
-# =========================================================================
-# TestRankingsAndHistory
-# =========================================================================
 
 class TestRankingsAndHistory:
-    """get_rankings and build_weight_history."""
-
     def test_get_rankings(self, score_tracker):
-        _make_eligible_group(score_tracker, {"hk_a": 0.90, "hk_b": 0.70})
-        # hk_c is NOT eligible (only 1 round)
-        _make_active(score_tracker, "hk_c", rounds=1, score=0.99)
+        _seed_participation(
+            score_tracker, ["hk_a", "hk_b", "hk_c"], MIN_PARTICIPATION_ROUNDS - 1
+        )
+        _record_scores(score_tracker, "r1", {"hk_a": 0.90, "hk_b": 0.70})
 
-        rankings = score_tracker.get_rankings(["hk_a", "hk_b", "hk_c"])
+        rankings = score_tracker.get_rankings(["hk_a", "hk_b", "hk_c", "hk_unknown"])
+
         assert rankings["hk_a"] == 1
         assert rankings["hk_b"] == 2
-        assert rankings["hk_c"] is None  # ineligible
+        assert rankings["hk_c"] is None
+        assert rankings["hk_unknown"] is None
 
-    def test_build_weight_history_structure(self, score_tracker_low_threshold):
-        tracker = score_tracker_low_threshold
-        _make_eligible_group(tracker, {"hk_a": 0.90, "hk_b": 0.70})
-
-        weights = tracker.get_winner_heavy_pruning_dust_weights(
+    def test_build_weight_history_structure(self, score_tracker):
+        _seed_participation(
+            score_tracker, ["hk_a", "hk_b"], MIN_PARTICIPATION_ROUNDS - 1
+        )
+        _record_scores(score_tracker, "r1", {"hk_a": 0.90, "hk_b": 0.70})
+        weights = score_tracker.get_winner_heavy_pruning_dust_weights(
             ["hk_a", "hk_b"], **DEFAULT_REWARD_POLICY
         )
-        entries = tracker.build_weight_history(
-            round_id="r_final",
+
+        entries = score_tracker.build_weight_history(
+            round_id="r1",
             validator_hotkey="val_hk",
             miner_hotkeys=["hk_a", "hk_b"],
             weights=weights,
@@ -658,15 +285,10 @@ class TestRankingsAndHistory:
         for entry in entries:
             assert set(entry.keys()) == keys
 
-        # Winner entry
         winner = [e for e in entries if e["miner_hotkey"] == "hk_a"][0]
+        assert winner["raw_score"] == pytest.approx(0.90)
+        assert winner["ema_score"] is None
         assert winner["weight"] == pytest.approx(DEFAULT_WINNER_WEIGHT)
         assert winner["eligible"] is True
+        assert winner["participation_count"] == MIN_PARTICIPATION_ROUNDS
         assert winner["rank"] == 1
-
-        loser = [e for e in entries if e["miner_hotkey"] == "hk_b"][0]
-        assert loser["weight"] == pytest.approx(
-            1.0 - DEFAULT_BURN_RATE - DEFAULT_WINNER_WEIGHT
-        )
-        assert loser["eligible"] is True
-        assert loser["rank"] == 2

--- a/utils/README.md
+++ b/utils/README.md
@@ -53,7 +53,7 @@ score = AdvancedScorer.compute_advanced_score(results)
 
 ### 2. Weight Tracking (weight_tracking.py)
 
-**Purpose:** Tracks miner performance over time with EMA smoothing and winner-heavy pruning dust weights.
+**Purpose:** Tracks current-round miner scores, recent-window participation eligibility, and winner-heavy pruning dust weights.
 
 **Main Class:** `ScoreTracker`
 
@@ -78,10 +78,10 @@ weights = tracker.get_winner_heavy_pruning_dust_weights(
 
 **Algorithm:**
 
-1. **EMA Smoothing:**
-2. **Winner-Heavy Pruning Dust:**
-3. **Participation Gating:** 
-4. **Normalization:** 
+1. **Round Score:** current-round AdvancedScorer `combined_final` only.
+2. **Participation Gating:** 10 valid scored rounds in the last 20 required; the current round counts.
+3. **Winner-Heavy Pruning Dust:** eligible rank #1 gets winner weight, ranks #2-#10 split dust.
+4. **Burn Remainder:** validator sends unallocated weight to the burn UID.
 
 ### 3. File Utils (file_utils.py)
 

--- a/utils/scoring.py
+++ b/utils/scoring.py
@@ -897,7 +897,7 @@ class HappyScorer:
             return self._get_zero_scores()
 
     def _get_zero_scores(self) -> Optional[Dict[str, float]]:
-        """Fail closed so the validator submits explicit combined_final=0.0."""
+        """Return no score so the validator can seek peer backfill."""
         return None
 
 

--- a/utils/weight_tracking.py
+++ b/utils/weight_tracking.py
@@ -1,52 +1,43 @@
 """
-EMA-based weight distribution with participation gating and score decay.
+Round-only winner weighting.
 
-Tracks miner performance over time with exponential moving averages.
-Weight distribution has two phases:
+Each Minos round is a fresh genomics challenge, so validator weights should be
+computed from that round's finalized scores only. Miners must still have valid
+scores in at least 10 of the last 20 finalized rounds before they can receive
+winner/dust weight; the current round counts. The class keeps the historic
+``ema_scores`` attribute name in memory for surrounding validator code, but the
+platform ``ema_score`` payload field is intentionally left empty while EMA is
+disabled.
 
-- Warmup (before any miner reaches min_rounds): positional reward split
-  50/30/20 among the top 3 scoring active miners (>= 1 round) by EMA.
-- Normal (once any miner is eligible): winner-heavy — the single
-  top-performing eligible miner receives the main reward, with pruning dust
-  distributed to the next ranked eligible miners.
-
-Eligibility requires scoring in at least `min_rounds` of the recent window.
-Tiebreaker: earliest submission timestamp in the most recent round.
-
-Inactive miners' EMA scores decay each round they miss, preventing stale
-high scores from persisting indefinitely.
+Weight distribution is winner-heavy: the top eligible current-round miner
+receives the configured winner weight, ranks #2..N receive pruning dust, and the
+caller sends the unallocated remainder to burn.
 """
 
 from typing import Dict, List, Any, Optional
 from collections import defaultdict
 import functools
 import logging
+import math
 import os
 
 logger = logging.getLogger(__name__)
 
-# Participation window: track last N rounds for eligibility checks
-PARTICIPATION_WINDOW = 20
-MIN_PARTICIPATION_ROUNDS = 10
+# Eligibility gate: score in at least 10 of the last 20 finalized rounds. The
+# current round is appended before weights are computed, so it counts.
+PARTICIPATION_WINDOW = int(os.getenv("PARTICIPATION_WINDOW", "20"))
+MIN_PARTICIPATION_ROUNDS = int(os.getenv("MIN_PARTICIPATION_ROUNDS", "10"))
+DEFAULT_DECAY_FACTOR = 1.0
 
-# EMA decay: multiply absent miners' EMA by this factor each round they miss.
-# 0.95 means a miner who misses 10 consecutive rounds sees their EMA drop to
-# ~60% of its original value  (0.95^10 ≈ 0.60).
-DEFAULT_DECAY_FACTOR = 0.95
-
-# Warmup phase: positional reward split among top N scoring active miners.
-# Index 0 = 1st place, 1 = 2nd, 2 = 3rd. Must sum to 1.0.
-WARMUP_TOP_N = 3
-WARMUP_WEIGHTS = [0.50, 0.30, 0.20]
-
-# Scores within this epsilon are treated as tied; tiebreak by submission time.
+# Scores within this epsilon are treated as tied; tiebreak by earliest
+# submission timestamp.
 SCORE_EPSILON = 0.005
-EMA_TOLERANCE = 1e-9
+ROUND_SCORE_TOLERANCE = 1e-9
+EMA_TOLERANCE = ROUND_SCORE_TOLERANCE
 
-# Canonical-ranking tiebreak. When a locally eligible canonical candidate is
-# within this absolute EMA gap of local rank 1, the canonical candidate is used
-# as the winner. This keeps close rounds aligned while leaving clearly separated
-# local EMA winners unchanged.
+# Canonical-ranking tiebreak. When a canonical candidate is within this absolute
+# current-round score gap of local rank 1, the canonical candidate is used as the
+# winner. This keeps validators aligned on close rounds.
 CANONICAL_TIEBREAK_TOLERANCE = 0.02
 
 # Minimum canonical coverage. Platform contributors below the per-validator
@@ -55,7 +46,7 @@ CANONICAL_TIEBREAK_TOLERANCE = 0.02
 CANONICAL_MIN_VALIDATOR_COUNT = int(os.getenv("CANONICAL_MIN_VALIDATOR_COUNT", "4"))
 CANONICAL_MIN_VALIDATOR_STAKE = float(os.getenv("CANONICAL_MIN_VALIDATOR_STAKE", "5000"))
 
-# Normal phase defaults. These are absolute validator-vector weights before
+# Reward defaults. These are absolute validator-vector weights before
 # Bittensor's u16 encoding: burn gets 0.87, rank #1 gets 0.10, and ranks
 # #2-#10 split the remaining 0.03 by geometric decay.
 DEFAULT_BURN_RATE = 0.87
@@ -65,10 +56,14 @@ DEFAULT_DUST_DECAY = 0.80
 
 
 class ScoreTracker:
-    """Track scores with EMA and phase-aware weight distribution.
+    """Track current-round scores plus recent-window participation counts.
 
     Miners are identified by hotkey (ss58 address) for stability across
     metagraph resyncs. UID mapping happens at weight-setting time.
+
+    ``ema_scores`` is intentionally retained as the public attribute used by
+    surrounding validator code. It now stores the current round's
+    combined_final score; platform history still receives ``ema_score=None``.
     """
 
     def __init__(
@@ -77,157 +72,125 @@ class ScoreTracker:
         min_rounds: int = MIN_PARTICIPATION_ROUNDS,
         decay_factor: float = None,
     ):
-        """
-        Initialize score tracker.
-
-        Args:
-            alpha: EMA smoothing factor (0 < alpha <= 1).
-                   Higher values weight recent scores more heavily.
-                   Defaults to EMA_ALPHA env var or 0.1.
-            min_rounds: Minimum rounds scored to be eligible for weights.
-            decay_factor: Multiplier applied to absent miners' EMA each round.
-                          Defaults to EMA_DECAY_FACTOR env var or 0.95.
-        """
-        self.alpha = alpha if alpha is not None else float(os.getenv("EMA_ALPHA", "0.1"))
+        # Compatibility only. Round-only scoring intentionally ignores EMA
+        # smoothing and decay; min_rounds is a recent-window eligibility gate.
+        self.alpha = alpha if alpha is not None else float(os.getenv("EMA_ALPHA", "1.0"))
         self.min_rounds = min_rounds
         self.decay_factor = decay_factor if decay_factor is not None else float(
             os.getenv("EMA_DECAY_FACTOR", str(DEFAULT_DECAY_FACTOR))
         )
 
-        # hotkey -> current EMA score
+        # hotkey -> current round score
         self.ema_scores: Dict[str, float] = {}
 
-        # hotkey -> most recent raw score (for reporting)
+        # hotkey -> current round raw score (same value, explicit for reporting)
         self.last_raw_scores: Dict[str, float] = {}
 
-        # Round participation history (sliding window)
-        # Each entry: {"round_id": str, "scored_hotkeys": set[str]}
+        # Recent finalized rounds for the 10-of-20 eligibility gate.
         self.round_history: List[dict] = []
-
-        # hotkey -> participation count (cached, updated on record_round)
         self._participation_counts: Dict[str, int] = defaultdict(int)
+        self._recorded_round_ids = set()
 
     def recover_from_platform_state(
         self,
         ema_entries: List[Dict[str, Any]],
         round_history: List[Dict[str, Any]],
     ):
-        """Rebuild tracker state from platform data after restart.
+        """Start fresh on scores while recovering recent participation.
 
-        Called once on startup to restore EMA scores and participation
-        history from the platform DB, avoiding the need to re-score.
-
-        Args:
-            ema_entries: List of {miner_hotkey, ema_score, participation_count, eligible}
-            round_history: List of {round_id, scored_hotkeys}
+        Historical platform scores are not loaded because old scores must not
+        influence the next round's ranking. Recent participation history is
+        loaded so the 10-of-20 eligibility gate survives validator restarts.
+        Restart recovery for a currently scoring round is handled separately by
+        /v2/get-submissions, which returns already-submitted scores for that
+        round.
         """
-        # Restore EMA scores
-        for entry in ema_entries:
-            hotkey = entry.get("miner_hotkey")
-            ema = entry.get("ema_score")
-            if hotkey and ema is not None:
-                self.ema_scores[hotkey] = ema
-
-        # Restore round history
-        self.round_history = [
-            {
-                "round_id": r["round_id"],
-                "scored_hotkeys": set(r.get("scored_hotkeys", [])),
+        self.ema_scores.clear()
+        self.last_raw_scores.clear()
+        self.round_history = []
+        self._recorded_round_ids = set()
+        self._participation_counts = defaultdict(int)
+        for entry in round_history or []:
+            if not isinstance(entry, dict):
+                continue
+            round_id = entry.get("round_id")
+            if not round_id:
+                continue
+            scored_hotkeys = {
+                hk for hk in entry.get("scored_hotkeys", []) if isinstance(hk, str) and hk
             }
-            for r in round_history
-        ]
-
-        # Trim to window
-        if len(self.round_history) > PARTICIPATION_WINDOW:
-            self.round_history = self.round_history[-PARTICIPATION_WINDOW:]
-
-        # Recalculate participation counts from history
+            self.round_history.append({
+                "round_id": round_id,
+                "scored_hotkeys": scored_hotkeys,
+            })
+        self.round_history = self.round_history[-PARTICIPATION_WINDOW:]
         self._recalculate_participation()
-
         logger.info(
-            f"State recovered: {len(self.ema_scores)} miners, "
-            f"{len(self.round_history)} rounds in history"
+            "Round-only score tracker initialized fresh; ignored "
+            f"{len(ema_entries or [])} historical score entries and recovered "
+            f"{len(self.round_history)} recent participation rounds"
         )
 
     def update(self, hotkey: str, raw_score: float) -> float:
-        """
-        Update EMA score for a miner.
-
-        Args:
-            hotkey: Miner's ss58 hotkey
-            raw_score: New raw score (e.g., combined_final from AdvancedScorer)
-
-        Returns:
-            Updated EMA score
-        """
-        # EMA starts at 0; first round yields α × S₀ (10% of first score)
-        old_ema = self.ema_scores.get(hotkey, 0.0)
-        new_ema = (1 - self.alpha) * old_ema + self.alpha * raw_score
-        self.ema_scores[hotkey] = new_ema
-        self.last_raw_scores[hotkey] = raw_score
-        return new_ema
+        """Record a miner's current-round score and return it."""
+        try:
+            score = float(raw_score)
+        except (TypeError, ValueError):
+            raise ValueError(f"Invalid round score for {hotkey[:16]}...: {raw_score!r}")
+        if not math.isfinite(score) or score <= 0.0 or score > 1.0:
+            raise ValueError(f"Round score out of range for {hotkey[:16]}...: {score!r}")
+        self.ema_scores[hotkey] = score
+        self.last_raw_scores[hotkey] = score
+        return score
 
     def record_round(self, round_id: str, scored_hotkeys: List[str]):
-        """
-        Record which miners scored in a round for participation tracking.
+        """Finalize the current round's participation set.
 
-        Call this once per round after all miners in that round have been scored.
-        Also applies EMA decay to miners who were absent this round.
-
-        Args:
-            round_id: Unique round identifier
-            scored_hotkeys: List of miner hotkeys that were scored this round
+        Scores for miners outside ``scored_hotkeys`` are dropped so stale state
+        can never leak into the next weight update.
         """
-        # Avoid recording the same round twice
-        for entry in self.round_history:
-            if entry["round_id"] == round_id:
-                logger.debug(f"Round {round_id} already recorded, skipping")
-                return
+        if round_id in self._recorded_round_ids:
+            logger.debug(f"Round {round_id} already recorded, skipping")
+            return
 
         scored_set = set(scored_hotkeys)
+        self.ema_scores = {
+            hk: score for hk, score in self.ema_scores.items() if hk in scored_set
+        }
+        self.last_raw_scores = {
+            hk: score for hk, score in self.last_raw_scores.items() if hk in scored_set
+        }
 
-        # Decay EMA for miners who did NOT participate in this round
-        if self.decay_factor < 1.0:
-            decayed = 0
-            for hotkey in list(self.ema_scores):
-                if hotkey not in scored_set:
-                    old = self.ema_scores[hotkey]
-                    self.ema_scores[hotkey] = old * self.decay_factor
-                    # Remove miners whose EMA has decayed to near-zero
-                    if self.ema_scores[hotkey] < 1e-6:
-                        del self.ema_scores[hotkey]
-                        self.last_raw_scores.pop(hotkey, None)
-                    else:
-                        decayed += 1
-            if decayed:
-                logger.debug(f"Decayed EMA for {decayed} absent miners (factor={self.decay_factor})")
+        counted_hotkeys = {
+            hk for hk in scored_set if self.ema_scores.get(hk, 0.0) > 0.0
+        }
 
         self.round_history.append({
             "round_id": round_id,
-            "scored_hotkeys": scored_set,
+            "scored_hotkeys": counted_hotkeys,
         })
-
-        # Trim to window size
-        if len(self.round_history) > PARTICIPATION_WINDOW:
-            self.round_history = self.round_history[-PARTICIPATION_WINDOW:]
-
-        # Recalculate participation counts
+        self.round_history = self.round_history[-PARTICIPATION_WINDOW:]
         self._recalculate_participation()
 
     def _recalculate_participation(self):
-        """Recalculate participation counts from round history."""
+        """Recalculate recent-window participation counts.
+
+        Counts are rebuilt from the last ``PARTICIPATION_WINDOW`` entries so a
+        miner that disappears eventually loses eligibility.
+        """
         counts: Dict[str, int] = defaultdict(int)
         for entry in self.round_history:
             for hotkey in entry["scored_hotkeys"]:
                 counts[hotkey] += 1
         self._participation_counts = counts
+        self._recorded_round_ids = {entry["round_id"] for entry in self.round_history}
 
     def get_participation_count(self, hotkey: str) -> int:
-        """Get the number of rounds a miner has scored in the recent window."""
+        """Return the miner's valid scored-round count in the recent window."""
         return self._participation_counts.get(hotkey, 0)
 
     def is_eligible(self, hotkey: str) -> bool:
-        """Check if a miner meets the minimum participation requirement."""
+        """Return whether a miner has met the recent-window round threshold."""
         return self.get_participation_count(hotkey) >= self.min_rounds
 
     def _sort_by_ema(
@@ -236,7 +199,7 @@ class ScoreTracker:
         submission_times: Optional[Dict[str, float]] = None,
         tolerance: float = EMA_TOLERANCE,
     ) -> List[str]:
-        """Sort hotkeys by EMA descending, tiebreaking by earliest submission."""
+        """Sort by current-round score descending, then earliest submission."""
         def _cmp(hk_a, hk_b):
             sa = self.ema_scores.get(hk_a, 0.0)
             sb = self.ema_scores.get(hk_b, 0.0)
@@ -253,11 +216,11 @@ class ScoreTracker:
         miner_hotkeys: List[str],
         submission_times: Optional[Dict[str, float]] = None,
     ) -> List[str]:
-        """Return eligible miners with positive EMA, ordered by local EMA."""
+        """Return eligible current-round scored miners with positive scores."""
         eligible = [hk for hk in miner_hotkeys if self.is_eligible(hk)]
         return [
             hk for hk in self._sort_by_ema(
-                eligible, submission_times, tolerance=EMA_TOLERANCE
+                eligible, submission_times, tolerance=ROUND_SCORE_TOLERANCE
             )
             if self.ema_scores.get(hk, 0.0) > 0
         ]
@@ -272,10 +235,10 @@ class ScoreTracker:
         if len(ranked) < 2:
             return False
 
-        top_ema = self.ema_scores.get(ranked[0], 0.0)
+        top_score = self.ema_scores.get(ranked[0], 0.0)
         return any(
-            (top_ema - self.ema_scores.get(hk, 0.0))
-            <= CANONICAL_TIEBREAK_TOLERANCE + EMA_TOLERANCE
+            (top_score - self.ema_scores.get(hk, 0.0))
+            <= CANONICAL_TIEBREAK_TOLERANCE + ROUND_SCORE_TOLERANCE
             for hk in ranked[1:]
         )
 
@@ -291,25 +254,7 @@ class ScoreTracker:
         canonical_top: Optional[str] = None,
         canonical_ranking: Optional[List[str]] = None,
     ) -> Dict[str, float]:
-        """
-        Compute absolute validator-vector miner weights.
-
-        Warmup keeps the existing 50/30/20 active-miner split, scaled to the
-        non-burn budget. Normal mode keeps rank #1 at ``winner_weight`` and
-        splits the remaining non-burn budget across ranks #2..dust_top_n.
-        Unused dust is intentionally left unallocated so the caller can add it
-        to burn.
-
-        If ``canonical_ranking`` is supplied, the validator scans it in order
-        and adopts the first locally eligible positive-EMA candidate within
-        ``CANONICAL_TIEBREAK_TOLERANCE`` of local rank 1. Local EMA order still
-        controls dust allocation.
-
-        ``canonical_top`` is retained as a backwards-compatible shorthand for
-        a one-item canonical ranking.
-
-        ``canonical_top=None`` keeps the default local-EMA ranking behavior.
-        """
+        """Compute round-only winner-heavy validator-vector miner weights."""
         weights = {hk: 0.0 for hk in miner_hotkeys}
         if not miner_hotkeys:
             return weights
@@ -331,54 +276,11 @@ class ScoreTracker:
         if dust_decay < 0.0:
             raise ValueError(f"dust_decay must be >= 0, got {dust_decay}")
 
-        eligible = [hk for hk in miner_hotkeys if self.is_eligible(hk)]
-
-        if not eligible:
-            active = [
-                hk for hk in miner_hotkeys
-                if self.get_participation_count(hk) > 0
-            ]
-            if not active:
-                logger.info("No active miners yet — all miner weights zero")
-                return weights
-
-            sorted_active = self._sort_by_ema(
-                active, submission_times, tolerance=SCORE_EPSILON
-            )
-            top_n = [
-                hk for hk in sorted_active[:WARMUP_TOP_N]
-                if self.ema_scores.get(hk, 0.0) > 0
-            ]
-            if top_n:
-                raw_w = WARMUP_WEIGHTS[:len(top_n)]
-                total_w = sum(raw_w)
-                for hk, raw in zip(top_n, raw_w):
-                    weights[hk] = miner_budget * raw / total_w
-                logger.info(
-                    f"Warmup: top-{len(top_n)} split over miner budget "
-                    f"{miner_budget:.4f}"
-                )
-            else:
-                equal_w = miner_budget / len(active) if active else 0.0
-                for hk in active:
-                    weights[hk] = equal_w
-                logger.info(
-                    f"Warmup: all active miners scored zero, "
-                    f"equal miner-budget split to {len(active)} active miners"
-                )
-            return weights
-
         ranked = self._ranked_positive_eligible(miner_hotkeys, submission_times)
-
         if not ranked:
-            logger.warning(
-                f"All {len(eligible)} eligible miners have zero EMA — "
-                f"returning zero miner weights (no-op)."
-            )
+            logger.warning("No positive current-round scores — returning zero miner weights")
             return weights
 
-        # Canonical-ranking tiebreak. Scan the ranking because the platform's
-        # top miner may not yet be locally eligible on every validator.
         winner = ranked[0]
         canonical_candidates: List[str] = []
         if canonical_ranking:
@@ -395,22 +297,22 @@ class ScoreTracker:
 
         if canonical_candidates:
             ranked_set = set(ranked)
-            top_ema = self.ema_scores.get(ranked[0], 0.0)
+            top_score = self.ema_scores.get(ranked[0], 0.0)
             for candidate in canonical_candidates:
                 if candidate not in ranked_set:
                     continue
                 if candidate == ranked[0]:
                     winner = candidate
                     break
-                canonical_ema = self.ema_scores.get(candidate, 0.0)
-                gap = top_ema - canonical_ema
-                if gap <= CANONICAL_TIEBREAK_TOLERANCE + EMA_TOLERANCE:
+                canonical_score = self.ema_scores.get(candidate, 0.0)
+                gap = top_score - canonical_score
+                if gap <= CANONICAL_TIEBREAK_TOLERANCE + ROUND_SCORE_TOLERANCE:
                     winner = candidate
                     logger.info(
-                        f"Canonical tiebreak: local rank-1 was "
-                        f"{ranked[0][:16]}... (ema={top_ema:.4f}); "
+                        f"Canonical tiebreak: local round rank-1 was "
+                        f"{ranked[0][:16]}... (score={top_score:.4f}); "
                         f"deferring to canonical winner {candidate[:16]}... "
-                        f"(ema={canonical_ema:.4f}, gap "
+                        f"(score={canonical_score:.4f}, gap "
                         f"{gap*100:.2f}% within "
                         f"{CANONICAL_TIEBREAK_TOLERANCE*100:.1f}% tolerance)"
                     )
@@ -419,9 +321,6 @@ class ScoreTracker:
         weights[winner] = winner_weight
 
         dust_pool = max(0.0, miner_budget - winner_weight)
-        # Dust remains ordered by local EMA, excluding the chosen winner. If
-        # canonical selects a non-local-rank-1 winner, the displaced local
-        # rank 1 remains eligible for the highest dust slot.
         dust_recipients = [hk for hk in ranked if hk != winner][:dust_top_n - 1]
         if dust_pool > 0 and dust_recipients:
             dust_raw = [dust_decay ** i for i in range(len(dust_recipients))]
@@ -431,35 +330,18 @@ class ScoreTracker:
                     weights[hk] = dust_pool * raw / dust_total
 
         logger.info(
-            f"Winner-heavy weights: winner={winner[:16]}... "
+            f"Round-only weights: winner={winner[:16]}... "
             f"winner_weight={winner_weight:.4f}, "
             f"dust_pool={dust_pool:.4f}, dust_recipients={len(dust_recipients)}"
         )
         return weights
 
     def get_rankings(self, miner_hotkeys: List[str]) -> Dict[str, Optional[int]]:
-        """
-        Get EMA-based rankings for all miners.
-        Only eligible miners are ranked (1 = best). Ineligible miners get None.
-
-        Args:
-            miner_hotkeys: List of miner hotkeys to rank.
-
-        Returns:
-            Dict of {hotkey: rank_or_None}
-        """
-        eligible_scores = []
-        for hk in miner_hotkeys:
-            if self.is_eligible(hk):
-                eligible_scores.append((hk, self.ema_scores.get(hk, 0.0)))
-
-        # Sort descending by EMA
-        eligible_scores.sort(key=lambda x: -x[1])
-
+        """Get current-round rankings. Unscored/zero-score miners get None."""
+        ranked = self._ranked_positive_eligible(miner_hotkeys)
         rankings: Dict[str, Optional[int]] = {hk: None for hk in miner_hotkeys}
-        for rank, (hk, _) in enumerate(eligible_scores, start=1):
+        for rank, hk in enumerate(ranked, start=1):
             rankings[hk] = rank
-
         return rankings
 
     def build_weight_history(
@@ -469,18 +351,7 @@ class ScoreTracker:
         miner_hotkeys: List[str],
         weights: Dict[str, float],
     ) -> List[Dict[str, Any]]:
-        """
-        Build the payload for submitting weight history to the platform.
-
-        Args:
-            round_id: The round these weights correspond to.
-            validator_hotkey: The validator's hotkey.
-            miner_hotkeys: All miner hotkeys.
-            weights: The weight dict from the active validator weight policy.
-
-        Returns:
-            List of entry dicts ready for the API.
-        """
+        """Build the platform weight-history payload."""
         rankings = self.get_rankings(miner_hotkeys)
 
         entries = []
@@ -488,7 +359,9 @@ class ScoreTracker:
             entries.append({
                 "miner_hotkey": hk,
                 "raw_score": self.last_raw_scores.get(hk),
-                "ema_score": self.ema_scores.get(hk),
+                # EMA is disabled for round-only scoring. Keep the field for
+                # schema compatibility, but do not backfill it with raw score.
+                "ema_score": None,
                 "rank": rankings.get(hk),
                 "weight": weights.get(hk, 0.0),
                 "eligible": self.is_eligible(hk),
@@ -498,18 +371,19 @@ class ScoreTracker:
         return entries
 
     def get_stats(self) -> Dict[str, Any]:
-        """Get current statistics for logging."""
+        """Get current round statistics for logging."""
         all_hotkeys = list(self.ema_scores.keys())
-        eligible_count = sum(1 for hk in all_hotkeys if self.is_eligible(hk))
-        ema_values = list(self.ema_scores.values())
+        score_values = list(self.ema_scores.values())
 
         return {
             "total_miners_tracked": len(all_hotkeys),
-            "eligible_count": eligible_count,
+            "eligible_count": sum(1 for hk in all_hotkeys if self.is_eligible(hk)),
             "rounds_tracked": len(self.round_history),
             "min_rounds_required": self.min_rounds,
-            "ema_alpha": self.alpha,
-            "decay_factor": self.decay_factor,
-            "top_ema": max(ema_values) if ema_values else 0.0,
-            "mean_ema": sum(ema_values) / len(ema_values) if ema_values else 0.0,
+            "ema_alpha": None,
+            "decay_factor": None,
+            "top_ema": max(score_values) if score_values else 0.0,
+            "mean_ema": sum(score_values) / len(score_values) if score_values else 0.0,
+            "top_round_score": max(score_values) if score_values else 0.0,
+            "mean_round_score": sum(score_values) / len(score_values) if score_values else 0.0,
         }


### PR DESCRIPTION
Replace EMA-based winner selection with current-round AdvancedScorer scores.

Keep 10-of-20 recent participation eligibility with the current round counted.

Stop submitting/ranking synthetic zero scores so failed local scoring can be backfilled.

Update validator docs and focused weight-tracking tests for round-only semantics.