### PR TITLE
Add practice mode and make --demo score your config

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,18 +168,31 @@ The installer automatically installs required runtime pieces where supported, in
 
 ### Try mining without registering
 
-Want to verify your variant-calling pipeline works before bonding TAO or registering a hotkey? Run the miner with **`--demo`**:
+Want to verify your variant-calling pipeline works — and see the score it earns — before bonding TAO or registering a hotkey? Run the miner with **`--demo`**:
 
 ```bash
 bash start-miner.sh --demo            # ephemeral keypair, no wallet needed
-# or, with PM2 / systemd:
-MINER_DEMO=true bash start-miner.sh   # equivalent — env var works the same as --flag
-bash pm2-miner.sh --demo              # PM2 launcher with the flag
+# or equivalently, via the env var:
+MINER_DEMO=true bash start-miner.sh   # env var works the same as --flag
 ```
 
-In demo mode the miner skips the chain entirely, generates an ephemeral keypair, downloads a static sandbox BAM from the platform's `/v2/demo/*` endpoints, runs your variant caller, and submits the result for acknowledgement. **Nothing is persisted, no score is computed, no TAO is earned** — it's purely a pipeline smoke test. When it prints `DEMO COMPLETE`, you know your Docker setup, reference data, variant caller, and platform connectivity all work end-to-end.
+> `--demo` is a one-shot foreground run — it scores once and exits. Run it directly, not under PM2 (which is for the long-running live miner).
 
-**Switching from demo to live**: the demo run creates a template `.env` with `MINER_DEMO=true` and placeholder `WALLET_NAME=default` / `WALLET_HOTKEY=default`. To switch to real mining: edit `.env` to set your real wallet name/hotkey, change `MINER_DEMO=true` → `MINER_DEMO=false` (or delete the line), and re-run `bash start-miner.sh`. Alternatively, run `bash start-miner.sh --setup` to redo the wallet wizard.
+`--demo` is a one-shot onboarding run: it skips the chain entirely, downloads a single fixed, fully-answered sample (BAM + truth), runs your variant caller, and prints the **exact score a validator would compute** — so you confirm your Docker setup, reference data, variant caller, and platform connectivity all work end-to-end *and* see the number your config gets. Nothing is persisted on-chain and no TAO is earned. (The sample is fixed for a repeatable first run; use `--practice` below to score against any sample.)
+
+**Switching from demo to live**: `--demo` needs no wallet and writes nothing. When you're ready to mine for real, run `bash start-miner.sh` (or `bash start-miner.sh --setup`) and follow the wizard to set your wallet and register your hotkey on subnet 107.
+
+### Score your config against any sample (practice mode)
+
+`--demo` scores one fixed sample; **`--practice`** lets you score against **any** of the fully-answered chr20/chr21 samples — pick from a menu, run your config, and see the **exact score a validator would compute** — no chain, no wallet, no live round at risk:
+
+```bash
+bash start-miner.sh --practice                                   # interactive: pick a sample, see your score
+bash start-miner.sh --practice --config configs/gatk.conf        # score a specific config
+bash start-miner.sh --practice --config configs/gatk.conf --sample-id <sample-id>   # skip the picker
+```
+
+Both `--demo` and `--practice` download truth on purpose so you can iterate offline: compare configs, tune, and only deploy to a live round once you're happy with the score. Neither touches the chain or earns TAO.
 
 **MinosVM:** If using the MinosVM image, everything is pre-installed. Just SSH in and run:
 

--- a/docs/tuning_guide.md
+++ b/docs/tuning_guide.md
@@ -143,7 +143,9 @@ The FP rate penalty ramps steeply once you exceed the dynamic threshold. If your
 
 ### Step 5: Test Locally First
 
-Use demo mode to run test jobs locally before committing to live rounds. A bad config can cost the current round and may fail to count toward eligibility if it produces no valid positive score.
+Use **demo mode** (`--demo`) for a one-shot check before committing to live rounds — it downloads a single fixed, fully-answered sample (BAM + truth), runs your variant caller, and prints the exact score a validator would compute.
+
+To score against **any** sample (not just the fixed demo one), use **practice mode** (`--practice`): pick from a menu of fully-answered chr20/chr21 samples and compare configs before going live. A bad config can cost the current round and may fail to count toward eligibility if it produces no valid positive score.
 
 ### The Core Tradeoff
 

--- a/ecosystem.miner.config.js
+++ b/ecosystem.miner.config.js
@@ -17,9 +17,10 @@ module.exports = {
       log_date_format: "YYYY-MM-DD HH:mm:ss Z",
       env: {
         PYTHONUNBUFFERED: "1",
-        // Uncomment to run against the platform /v2/demo/* sandbox
-        // (ephemeral keypair, no wallet/registration, no TAO earned):
-        //   MINER_DEMO: "true",
+        // PM2 runs the long-running live miner. For a one-shot, walletless
+        // scored test run, do NOT set MINER_DEMO here (demo/practice exit
+        // after one run and a supervisor would restart-loop them) — instead
+        // run in the foreground: bash start-miner.sh --demo  (or --practice).
       },
     },
   ],

--- a/install.sh
+++ b/install.sh
@@ -606,7 +606,7 @@ install_deps() {
         exit 1
     fi
 
-    info "Installing Python dependencies (includes PyTorch ~2 GB; this may take 5-15 minutes)."
+    info "Installing Python dependencies (includes the CPU build of PyTorch ~200 MB; a few minutes)."
     if ! run_quiet "Upgrading pip" "/tmp/minos-pip-upgrade.log" pip install --upgrade pip -q; then
         fail "pip upgrade failed. Check /tmp/minos-pip-upgrade.log for details."
         exit 1

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -4,6 +4,7 @@ import sys
 import os
 import gzip
 import json
+import re
 import secrets
 import shutil
 import traceback
@@ -111,7 +112,7 @@ class Miner:
                 )
                 bt.logging.info(
                     "To test your pipeline without registering, restart with --demo "
-                    "(uses an ephemeral keypair against the platform's sandboxed demo round)."
+                    "(a walletless one-shot that scores your config on a fixed sample)."
                 )
 
         self.setup_variant_caller()
@@ -207,11 +208,69 @@ class Miner:
             action="store_true",
             default=False,
             help=(
-                "Run in demo mode: skips chain (no subtensor/metagraph), "
-                "uses an ephemeral keypair, and routes to the platform's "
-                "/v2/demo/* sandbox so a new operator can prove their "
-                "pipeline works without registering on the subnet."
+                "One-shot onboarding self-score: no chain, no wallet. Downloads "
+                "a single fixed, fully-answered sample (BAM + truth), runs your "
+                "config, and prints the exact score a validator would compute — "
+                "so a new operator can verify their pipeline and see its score "
+                "without registering. Use --practice to score against any sample."
             ),
+        )
+        # --- Offline self-scoring (no chain, no platform) ---
+        # Runs the miner's config against a local BAM + truth and prints the
+        # EXACT combined_final a validator would compute. Requires only Docker
+        # (GATK + hap.py) and a local reference. Handled in main() before the
+        # full Miner (wallet/chain/platform) is ever constructed.
+        parser.add_argument(
+            "--score",
+            action="store_true",
+            default=False,
+            help=(
+                "Offline self-score: run your config against a local BAM + "
+                "truth VCF and print the exact validator score. No chain, no "
+                "platform, no wallet. Use with --bam/--truth/--region "
+                "(+optional --mutations/--config/--reference)."
+            ),
+        )
+        parser.add_argument(
+            "--practice",
+            action="store_true",
+            default=False,
+            help=(
+                "Interactive practice mode: pick a fully-answered chr20/chr21 "
+                "sample from the platform, download its BAM + truth + "
+                "mutations (reused if already downloaded), run your config, and "
+                "self-score with the validator scorer. No chain. Optionally "
+                "pass --config to score immediately, or --sample_id to skip "
+                "the picker."
+            ),
+        )
+        parser.add_argument(
+            "--sample_id", type=str, default=None,
+            help="[--practice] Skip the interactive picker and use this sample id directly.",
+        )
+        parser.add_argument("--bam", type=str, default=None, help="[--score] Path to input BAM.")
+        parser.add_argument("--truth", type=str, default=None, help="[--score] Path to truth VCF (.vcf.gz).")
+        parser.add_argument(
+            "--mutations", type=str, default=None,
+            help="[--score] Path to mutations-only VCF (.vcf.gz). Strongly recommended — the validator scores with it.",
+        )
+        parser.add_argument("--region", type=str, default=None, help="[--score] Region, e.g. chr20:45000000-50000000.")
+        parser.add_argument(
+            "--config", type=str, default=None,
+            help="[--score] Config file to score. A GATK .conf (same format as configs/gatk.conf) or a JSON "
+                 "of gatk_options. Defaults to configs/<tool>.conf.",
+        )
+        parser.add_argument(
+            "--reference", type=str, default=None,
+            help="[--score] Reference FASTA. Defaults to datasets/reference/<chrom>/<chrom>.fa.",
+        )
+        parser.add_argument(
+            "--confident_bed", type=str, default=None,
+            help="[--score] Optional confident-regions BED (matches the validator's confident_bed).",
+        )
+        parser.add_argument(
+            "--reference_sdf", type=str, default=None,
+            help="[--score] Optional RTG SDF for the reference (speeds up hap.py; built on the fly if omitted).",
         )
 
         bt.subtensor.add_args(parser)
@@ -423,6 +482,12 @@ class Miner:
             bam_url, bam_url_backup = bam_url_s3, bam_url_hip
             bam_index_url, bam_index_url_backup = bam_index_url_s3, bam_index_url_hip
 
+        # Never leave the primary slot None when only the backup is set:
+        # download_file_with_fallback dereferences the primary URL before its
+        # try/except, so a None primary would raise instead of falling back.
+        bam_url, bam_url_backup = _coalesce_urls(bam_url, bam_url_backup)
+        bam_index_url, bam_index_url_backup = _coalesce_urls(bam_index_url, bam_index_url_backup)
+
         if not bam_url and not bam_url_backup:
             bt.logging.error("Round has no BAM URL - cannot process")
             return None
@@ -451,11 +516,13 @@ class Miner:
         bam_index = Path(str(bam_path) + ".bai")
         if bam_index.exists():
             bam_index.unlink()
-        if bam_index_url or bam_index_url_backup:
+        if bam_index_url:
+            # _coalesce_urls above guarantees bam_index_url is set whenever any
+            # index URL (primary or backup) exists, so the fallback covers both.
             print(f"   Downloading BAM index...", flush=True)
             index_downloaded = download_file_with_fallback(
                 bam_index_url, bam_index, backup_url=bam_index_url_backup, show_progress=False
-            ) if bam_index_url else download_file_verified(bam_index_url_backup, bam_index, show_progress=False)
+            )
             if index_downloaded and index_downloaded.exists():
                 print(f"   BAM index downloaded", flush=True)
             else:
@@ -581,6 +648,12 @@ class Miner:
                 print(f"", flush=True)
                 print(f"   Submission was accepted by the demo sandbox — nothing", flush=True)
                 print(f"   is persisted, no score is computed, no TAO is earned.", flush=True)
+                print(f"", flush=True)
+                print(f"   To actually SCORE and improve your config, use practice", flush=True)
+                print(f"   mode — it serves fully-answered chr20/chr21 samples and", flush=True)
+                print(f"   scores your config with the exact validator scorer:", flush=True)
+                print(f"     python neurons/miner.py --practice --config configs/{self.variant_caller}.conf", flush=True)
+                print(f"", flush=True)
                 print(f"   Register your hotkey on subnet 107 to participate in", flush=True)
                 print(f"   live rounds:", flush=True)
                 print(f"     btcli subnets register --netuid 107 \\", flush=True)
@@ -744,9 +817,966 @@ class Miner:
         asyncio.run(self.run_async())
 
 
+# ---------------------------------------------------------------------------
+# Practice-mode UI helpers. Match the setup wizard's look (rich + questionary)
+# when the terminal is interactive, and degrade gracefully to plain text when
+# it isn't (piped input, non-TTY, or the libs are missing) so scripted runs
+# and --sample_id still work.
+# ---------------------------------------------------------------------------
+class _PracticeUI:
+    def __init__(self):
+        self.console = None
+        self.questionary = None
+        self.Panel = self.Table = self.Text = self.Align = None
+        # Interactive only when stdin AND stdout are real TTYs.
+        self.interactive = sys.stdin.isatty() and sys.stdout.isatty()
+        try:
+            from rich.console import Console
+            from rich.panel import Panel
+            from rich.table import Table
+            from rich.text import Text
+            from rich.align import Align
+            self.console = Console()
+            self.Panel, self.Table, self.Text, self.Align = Panel, Table, Text, Align
+        except Exception:
+            pass
+        try:
+            import questionary
+            from questionary import Style as QStyle
+            self.questionary = questionary
+            self._qstyle = QStyle([
+                ("qmark", "fg:cyan bold"),
+                ("question", "bold"),
+                ("answer", "fg:green bold"),
+                ("pointer", "fg:cyan bold"),
+                ("highlighted", "fg:cyan bold"),
+                ("selected", "fg:green"),
+            ])
+        except Exception:
+            self._qstyle = None
+
+    def banner(self, tool):
+        if self.console and self.Panel:
+            self.console.print()
+            self.console.print(self.Panel(
+                "[bold cyan]MINOS PRACTICE MODE[/]\n"
+                "[dim]Run your config on fully-answered samples and see the exact "
+                "score a validator would give.[/]\n"
+                f"[dim]Tool:[/] [bold green]{tool}[/]   [dim]•  no wallet, no chain[/]",
+                border_style="cyan", padding=(1, 2),
+            ))
+        else:
+            print(f"\n{'='*60}\n   PRACTICE MODE  ({tool})\n{'='*60}", flush=True)
+
+    async def select(self, message, choices, plain_prompt):
+        """choices: list of (label, value). Returns a value, or None to quit.
+        plain_prompt: fn(choices)->value for the non-interactive fallback.
+
+        Async because run_practice runs inside an event loop — questionary's
+        blocking .ask() calls asyncio.run() internally, which raises "cannot be
+        called from a running event loop". .ask_async() awaits on the loop we
+        already have.
+        """
+        if self.interactive and self.questionary:
+            qchoices = [self.questionary.Choice(label, value=val) for label, val in choices]
+            ans = await self.questionary.select(message, choices=qchoices, style=self._qstyle).ask_async()
+            return ans  # None if the user hit Ctrl-C / esc
+        return plain_prompt(choices)
+
+    async def confirm_tool(self, default_tool):
+        if self.interactive and self.questionary:
+            ans = await self.questionary.select(
+                f"Which tool should score your config?",
+                choices=[
+                    self.questionary.Choice(f"{default_tool}  (from your .env — recommended)", value=default_tool),
+                    *[self.questionary.Choice(t, value=t)
+                      for t in ("gatk", "deepvariant", "bcftools") if t != default_tool],
+                ],
+                style=self._qstyle,
+            ).ask_async()
+            return ans or default_tool
+        return default_tool
+
+    def info(self, msg):
+        if self.console:
+            self.console.print(f"   {msg}")
+        else:
+            print(f"   {msg}", flush=True)
+
+    def sample_table(self, samples, allow_all):
+        if self.console and self.Table:
+            t = self.Table(show_header=True, header_style="bold cyan", border_style="cyan", padding=(0, 1))
+            t.add_column("#", justify="right", style="bold")
+            t.add_column("Sample", style="bold white")
+            t.add_column("Chr")
+            t.add_column("Region")
+            t.add_column("Mutations", justify="right")
+            for i, s in enumerate(samples, 1):
+                t.add_row(str(i), s.get("sample_id", ""), s.get("chromosome", ""),
+                          s.get("region", ""), str(s.get("num_mutations", "")))
+            self.console.print(self.Panel(t, title="Practice samples", border_style="cyan", padding=(0, 1)))
+        else:
+            print("\n   Available practice samples:", flush=True)
+            for i, s in enumerate(samples, 1):
+                print(f"     {i}. {s.get('sample_id')}  [{s.get('chromosome')} {s.get('region')}]  "
+                      f"mutations={s.get('num_mutations')}", flush=True)
+            if allow_all:
+                print(f"     a. ALL — download every sample", flush=True)
+
+    def result_panel(self, metrics, advanced_score, combined_final, would_record, zero_input):
+        if not (self.console and self.Panel and self.Table):
+            # Plain fallback
+            print(f"\n{'='*60}\n   RESULT\n{'='*60}", flush=True)
+            print(f"   SNP    F1={metrics.get('f1_snp', 0):.4f}  recall={metrics.get('recall_snp', 0):.4f}  "
+                  f"prec={metrics.get('precision_snp', 0):.4f}  FP={metrics.get('fp_snp', 0)}", flush=True)
+            print(f"   INDEL  F1={metrics.get('f1_indel', 0):.4f}  recall={metrics.get('recall_indel', 0):.4f}  "
+                  f"prec={metrics.get('precision_indel', 0):.4f}  FP={metrics.get('fp_indel', 0)}", flush=True)
+            print(f"\n   ADVANCED SCORE:   {advanced_score:.4f} / 100", flush=True)
+            if would_record:
+                print(f"   COMBINED_FINAL:   {combined_final:.6f}   <-- what a validator records", flush=True)
+            elif zero_input:
+                print(f"   COMBINED_FINAL:   {combined_final:.6f}   <-- ZERO-INPUT: a validator discards this "
+                      f"(called nothing on-target).", flush=True)
+            else:
+                print(f"   COMBINED_FINAL:   {combined_final:.6f}   <-- out of range; a validator discards this.",
+                      flush=True)
+            print(f"{'='*60}\n", flush=True)
+            return
+
+        # Rich metrics table
+        t = self.Table(show_header=True, header_style="bold cyan", box=None, padding=(0, 2))
+        t.add_column("Type", style="bold white")
+        t.add_column("F1", justify="right")
+        t.add_column("Recall", justify="right")
+        t.add_column("Precision", justify="right")
+        t.add_column("FP", justify="right")
+        for label, k in (("SNP", "snp"), ("INDEL", "indel")):
+            f1 = metrics.get(f"f1_{k}", 0)
+            f1c = "green" if f1 >= 0.95 else "yellow" if f1 >= 0.80 else "red"
+            t.add_row(label, f"[{f1c}]{f1:.4f}[/]",
+                      f"{metrics.get(f'recall_{k}', 0):.4f}",
+                      f"{metrics.get(f'precision_{k}', 0):.4f}",
+                      str(metrics.get(f"fp_{k}", 0)))
+
+        # Big score line, color-banded
+        band = "green" if combined_final >= 0.90 else "yellow" if combined_final >= 0.70 else "red"
+        if would_record:
+            verdict = f"[bold {band}]COMBINED_FINAL  {combined_final:.6f}[/]\n[dim]This is exactly what a validator would record.[/]"
+            border = band
+        elif zero_input:
+            verdict = (f"[bold red]COMBINED_FINAL  {combined_final:.6f}[/]\n"
+                       "[red]ZERO-INPUT — a validator DISCARDS this.[/] "
+                       "[dim]Your config called nothing on-target; it earns no on-chain score.[/]")
+            border = "red"
+        else:
+            verdict = (f"[bold red]COMBINED_FINAL  {combined_final:.6f}[/]\n"
+                       "[red]Out of range — a validator discards this.[/]")
+            border = "red"
+
+        from rich.console import Group
+        body = Group(
+            t,
+            self.Text(""),
+            self.console.render_str(f"[dim]Advanced score:[/] [bold]{advanced_score:.4f}[/] / 100"),
+            self.Text(""),
+            self.console.render_str(verdict),
+        )
+        self.console.print()
+        self.console.print(self.Panel(body, title="Your score", border_style=border, padding=(1, 2)))
+        self.console.print()
+
+
+# Single shared UI instance for the process.
+_UI = _PracticeUI()
+
+
+def _load_config_for_scoring(config_path: Optional[str], tool: str) -> Dict[str, Any]:
+    """Load a config file into the {tool}_options dict the templates expect.
+
+    Accepts either a GATK-style `.conf` (key=value lines, same format as
+    configs/gatk.conf) or a JSON file. JSON may be either a bare options dict
+    ({"min_base_quality_score": 10, ...}) or a full config already wrapping
+    "<tool>_options". Falls back to configs/<tool>.conf when no path is given —
+    exactly the source the live miner submits from.
+    """
+    opts_key = f"{tool}_options"
+
+    if not config_path:
+        # Same path _get_tool_config() uses for a live submission.
+        return {opts_key: extract_tool_options(tool)}
+
+    p = Path(config_path)
+    if not p.exists():
+        raise FileNotFoundError(f"Config file not found: {p}")
+
+    text = p.read_text()
+    # Try JSON first (a leading brace is unambiguous vs. key=value .conf).
+    stripped = text.lstrip()
+    if stripped.startswith("{"):
+        data = json.loads(text)
+        if opts_key in data and isinstance(data[opts_key], dict):
+            return {opts_key: data[opts_key]}
+        # Bare options dict — strip any non-option scalars defensively.
+        return {opts_key: {k: v for k, v in data.items()
+                           if not isinstance(v, (dict, list))}}
+
+    # Otherwise parse as a .conf (key=value, # comments, blank lines).
+    options: Dict[str, Any] = {}
+    for line_num, raw in enumerate(text.splitlines(), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            raise ValueError(f"{p}:{line_num}: expected key=value, got: {raw!r}")
+        key, _, val = line.partition("=")
+        key, val = key.strip(), val.strip()
+        # Coerce to the same scalar types extract_tool_options produces.
+        if val.lower() in ("true", "false"):
+            options[key] = (val.lower() == "true")
+        else:
+            try:
+                options[key] = int(val)
+            except ValueError:
+                try:
+                    options[key] = float(val)
+                except ValueError:
+                    options[key] = val
+    return {opts_key: options}
+
+
+def run_offline_score(cfg) -> int:
+    """Score a config against a local BAM+truth, exactly as a validator would.
+
+    Pipeline mirrors validator._run_miner_tool -> HappyScorer.score_vcf ->
+    AdvancedScorer.compute_advanced_score -> /100 -> _valid_round_score. No
+    chain, no wallet, no platform. Returns a process exit code. The run+score
+    core is shared with --practice via _run_and_score().
+    """
+    tool = (getattr(cfg, "variant_caller", None) or os.getenv("MINER_TEMPLATE") or "gatk").lower()
+
+    # --- Validate required inputs ---
+    missing = [f for f in ("bam", "truth", "region") if not getattr(cfg, f, None)]
+    if missing:
+        print(f"ERROR: --score requires {', '.join('--' + m for m in missing)}", flush=True)
+        return 2
+
+    bam_path = Path(cfg.bam).resolve()
+    truth_path = Path(cfg.truth).resolve()
+    region = cfg.region
+    mutations_path = Path(cfg.mutations).resolve() if cfg.mutations else None
+
+    # Structurally validate the region before it is interpolated into the
+    # variant-caller/Docker command. Expected: <contig>:<start>-<end>.
+    if not re.match(r"^[A-Za-z0-9_.]+:\d+-\d+$", region or ""):
+        print(f"ERROR: --region must look like chr20:45000000-50000000 (got: {region!r})", flush=True)
+        return 2
+
+    if not bam_path.exists():
+        print(f"ERROR: BAM not found: {bam_path}", flush=True)
+        return 2
+    if not truth_path.exists():
+        print(f"ERROR: truth VCF not found: {truth_path}", flush=True)
+        return 2
+    if mutations_path and not mutations_path.exists():
+        print(f"ERROR: mutations VCF not found: {mutations_path}", flush=True)
+        return 2
+
+    try:
+        require_docker()
+    except RuntimeError as e:
+        print(f"ERROR: {e}", flush=True)
+        return 2
+
+    # --- Resolve reference (same convention as execute_template) ---
+    chrom = region.split(":")[0] if region else "chr20"
+    if cfg.reference:
+        ref_path = Path(cfg.reference).resolve()
+    else:
+        ref_path = BASE_DIR / "datasets" / "reference" / chrom / f"{chrom}.fa"
+        if not ref_path.exists():
+            legacy = BASE_DIR / "datasets" / "reference" / "chr20.fa"
+            if chrom == "chr20" and legacy.exists():
+                ref_path = legacy
+    if not ref_path.exists():
+        print(f"ERROR: reference not found: {ref_path}\n"
+              f"       Pass --reference, or place it at datasets/reference/{chrom}/{chrom}.fa", flush=True)
+        return 2
+
+    # --- Ensure indexes the template requires (.bai / .fai) ---
+    if not _ensure_bam_index(bam_path):
+        return 2
+    if not _ensure_fasta_index(ref_path):
+        return 2
+
+    # --- Load the config to score, wrapped as templates expect ---
+    try:
+        tool_config = _load_config_for_scoring(cfg.config, tool)
+    except (FileNotFoundError, ValueError, json.JSONDecodeError) as e:
+        print(f"ERROR: could not load config: {e}", flush=True)
+        return 2
+
+    opts = tool_config.get(f"{tool}_options", {})
+    print(f"\n{'='*60}", flush=True)
+    print(f"   OFFLINE SELF-SCORE  ({tool})", flush=True)
+    print(f"{'='*60}", flush=True)
+    print(f"   Region:    {region}", flush=True)
+    print(f"   BAM:       {bam_path.name}", flush=True)
+    print(f"   Truth:     {truth_path.name}", flush=True)
+    print(f"   Mutations: {mutations_path.name if mutations_path else '(none — score may differ from validator)'}", flush=True)
+    print(f"   Reference: {ref_path.name}", flush=True)
+    print(f"   Config:    {cfg.config or f'configs/{tool}.conf'}  ({len(opts)} params)", flush=True)
+
+    score = _run_and_score(
+        tool=tool,
+        tool_config=tool_config,
+        bam_path=bam_path,
+        ref_path=ref_path,
+        truth_path=truth_path,
+        mutations_path=mutations_path,
+        region=region,
+        confident_bed=cfg.confident_bed if cfg.confident_bed else None,
+        reference_sdf=cfg.reference_sdf if cfg.reference_sdf else None,
+    )
+    return 0 if score is not None else 1
+
+
+def _run_and_score(tool, tool_config, bam_path, ref_path, truth_path,
+                   mutations_path, region, confident_bed=None, reference_sdf=None):
+    """Run a config and score it exactly as a validator would.
+
+    Shared by --score and --practice. Runs the template, then scores with
+    HappyScorer + AdvancedScorer and prints the validator's combined_final
+    plus the component breakdown. Returns combined_final (float) on success,
+    or None on any failure (variant calling failed, no VCF, hap.py returned
+    no metrics).
+    """
+    from utils.scoring import HappyScorer, AdvancedScorer
+    from templates import load_template
+
+    # --- Run variant calling (validator._run_miner_tool equivalent) ---
+    out_dir = bam_path.parent / "score_run"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    output_vcf = out_dir / "output.vcf.gz"
+
+    run_config = {
+        **tool_config,
+        "timeout": GENOMICS_CONFIG.get("variant_calling_timeout", 1800),
+        "threads": MINER_CONFIG.get("num_threads", 4),
+        "ref_build": "GRCh38",
+    }
+
+    print(f"\n   Running {tool.upper()}...", flush=True)
+    t0 = time.time()
+    template = load_template(tool)
+    result = template.variant_call(
+        bam_path=bam_path,
+        reference_path=ref_path,
+        output_vcf_path=output_vcf,
+        region=region,
+        config=run_config,
+    )
+    if not result.get("success"):
+        print(f"   ERROR: variant calling failed: {result.get('error', 'unknown')}", flush=True)
+        return None
+    variant_count = result.get("variant_count", 0)
+    print(f"   Variants called: {variant_count}  ({time.time() - t0:.0f}s)", flush=True)
+
+    query_vcf = output_vcf if output_vcf.exists() else None
+    if not query_vcf:
+        for ext in (".vcf.gz", ".vcf"):
+            alt = out_dir / f"output{ext}"
+            if alt.exists():
+                query_vcf = alt
+                break
+    if not query_vcf:
+        print("   ERROR: no output VCF produced", flush=True)
+        return None
+
+    # --- Resolve the RTG SDF (required by vcfeval for deterministic scoring) ---
+    # If not passed explicitly, look for it next to the reference using the same
+    # convention the validator uses: datasets/reference/<chrom>/<chrom>.sdf.
+    sdf_arg = reference_sdf
+    if not sdf_arg:
+        chrom = region.split(":")[0] if region else "chr20"
+        for cand in (
+            BASE_DIR / "datasets" / "reference" / chrom / f"{chrom}.sdf",
+            BASE_DIR / "datasets" / "reference" / f"{chrom}.sdf",
+            ref_path.parent / f"{chrom}.sdf",
+        ):
+            if cand.is_dir():
+                sdf_arg = str(cand)
+                break
+    if not sdf_arg:
+        chrom = region.split(":")[0] if region else "chr20"
+        print(f"   ERROR: RTG SDF not found for {chrom} (needed to score).", flush=True)
+        print(f"          Expected at datasets/reference/{chrom}/{chrom}.sdf — "
+              f"run practice via start-miner.sh, which fetches it.", flush=True)
+        return None
+
+    # --- Score exactly as the validator does ---
+    print(f"\n   Scoring with hap.py...", flush=True)
+    scorer = HappyScorer()
+    metrics = scorer.score_vcf(
+        truth_vcf=str(truth_path),
+        query_vcf=str(query_vcf),
+        reference_fasta=str(ref_path),
+        confident_bed=confident_bed,
+        region=region,
+        reference_sdf=sdf_arg,
+        mutations_vcf=str(mutations_path) if mutations_path else None,
+    )
+    if metrics is None:
+        print("   ERROR: hap.py returned no valid metrics", flush=True)
+        return None
+
+    advanced_score = AdvancedScorer.compute_advanced_score(metrics)
+    combined_final = advanced_score / 100.0
+
+    # Two guards match what a validator applies before recording a score:
+    #   1. combined_final must be a finite number in (0, 1].
+    #   2. a config that calls nothing on-target (SNP and indel F1 both 0) is
+    #      not a scorable result — it is discarded rather than recorded, so it
+    #      earns no on-chain score. Report that honestly instead of implying
+    #      the number would count.
+    valid_range = (isinstance(combined_final, float) and combined_final == combined_final
+                   and 0.0 < combined_final <= 1.0)
+    # Match the validator's empty-on-target discard EXACTLY (see the validator's
+    # _is_zero_input_advanced_fingerprint): both F1s zero AND the fused score in
+    # the all-zero band. Using only the F1s would over-report "discarded" for a
+    # zero-F1 config that still made calls (germline/FP) — the validator records
+    # those, so the local preview must not claim otherwise.
+    zero_input = (
+        (metrics.get("f1_snp") or 0.0) == 0.0
+        and (metrics.get("f1_indel") or 0.0) == 0.0
+        and 0.24999 <= combined_final <= 0.25001
+    )
+    would_record = valid_range and not zero_input
+
+    # --- Report (mirror the validator's component breakdown), styled ---
+    _UI.result_panel(metrics, advanced_score, combined_final, would_record, zero_input)
+    return combined_final
+
+
+def _ensure_bam_index(bam_path: Path) -> bool:
+    """Create a .bai next to the BAM if none exists (samtools via Docker)."""
+    if Path(f"{bam_path}.bai").exists() or bam_path.with_suffix(".bam.bai").exists():
+        return True
+    print(f"   Creating BAM index for {bam_path.name}...", flush=True)
+    try:
+        subprocess.run(
+            ["docker", "run", "--rm", "-v", f"{bam_path.parent}:/data",
+             "quay.io/biocontainers/samtools:1.20--h50ea8bc_0",
+             "samtools", "index", f"/data/{bam_path.name}"],
+            check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, timeout=600,
+        )
+        return Path(f"{bam_path}.bai").exists() or bam_path.with_suffix(".bam.bai").exists()
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        print(f"   ERROR: failed to index BAM: {e}", flush=True)
+        return False
+
+
+def _ensure_fasta_index(ref_path: Path) -> bool:
+    """Create a .fai next to the reference if none exists (samtools via Docker)."""
+    if Path(f"{ref_path}.fai").exists():
+        return True
+    print(f"   Creating reference index for {ref_path.name}...", flush=True)
+    try:
+        subprocess.run(
+            ["docker", "run", "--rm", "-v", f"{ref_path.parent}:/data",
+             "quay.io/biocontainers/samtools:1.20--h50ea8bc_0",
+             "samtools", "faidx", f"/data/{ref_path.name}"],
+            check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, timeout=600,
+        )
+        return Path(f"{ref_path}.fai").exists()
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        print(f"   ERROR: failed to index reference: {e}", flush=True)
+        return False
+
+
+def _resolve_reference_for(chrom: str) -> Optional[Path]:
+    """Locate the reference FASTA for a chromosome (same convention as
+    execute_template). Returns None if not present."""
+    ref_path = BASE_DIR / "datasets" / "reference" / chrom / f"{chrom}.fa"
+    if ref_path.exists():
+        return ref_path
+    legacy = BASE_DIR / "datasets" / "reference" / "chr20.fa"
+    if chrom == "chr20" and legacy.exists():
+        return legacy
+    return None
+
+
+def _coalesce_urls(primary, backup):
+    """Ensure the primary slot is never None when a usable URL exists.
+
+    download_file_with_fallback -> download_file does `url.startswith(...)`
+    BEFORE its try/except, so a None primary raises an uncaught AttributeError
+    instead of falling back. If primary is falsy, promote the backup into the
+    primary slot. Returns (primary, backup) with primary guaranteed non-None
+    whenever either input was set.
+    """
+    if not primary and backup:
+        return backup, None
+    return primary, backup
+
+
+def _reuse_ok(path: Path, expected_sha256) -> bool:
+    """Whether an already-on-disk file may be reused without re-downloading.
+
+    Requires the file to exist and be non-empty. When the sample carries a
+    sha256, the file must also match it — so a truncated file left by an
+    interrupted prior run is NOT silently reused (which would corrupt the
+    self-score). With no expected sha256, a non-empty file is accepted.
+    """
+    try:
+        if not path.exists() or path.stat().st_size == 0:
+            return False
+    except OSError:
+        return False
+    if expected_sha256:
+        try:
+            from utils.file_utils import compute_sha256
+            if compute_sha256(path) != expected_sha256:
+                print(f"   {path.name} on disk fails sha256 — will re-download.", flush=True)
+                return False
+        except Exception:
+            # If we can't verify, be safe and re-download.
+            return False
+    return True
+
+
+def _download_index_best_effort(url, backup, dest: Path) -> None:
+    """Download an index file (.bai/.tbi) if a URL slot exists; never raises.
+
+    Index files are optional (hap.py/samtools can rebuild them), so any
+    failure here is non-fatal. Coalesces the primary slot so a None primary
+    with a set backup doesn't crash download_file_with_fallback.
+    """
+    if not url and not backup:
+        return
+    primary, bkp = _coalesce_urls(url, backup)
+    try:
+        download_file_with_fallback(primary, dest, backup_url=bkp, show_progress=False)
+    except Exception as e:
+        bt.logging.debug(f"Index download for {dest.name} failed (non-fatal): {e}")
+
+
+def _download_practice_files(sample: dict) -> Optional[dict]:
+    """Download a practice sample's BAM + truth + mutations, reusing any
+    already-downloaded files. Returns paths dict, or None on failure.
+
+    Files land in datasets/practice/<sample_id>/. Uses the primary URL the
+    platform returns, with the backup URL as fallback — same ordering as the
+    round path.
+    """
+    from utils.path_utils import safe_round_dir_name
+
+    sample_id = sample["sample_id"]
+    out_dir = BASE_DIR / "datasets" / "practice" / safe_round_dir_name(sample_id)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    _prefer_hippius = os.getenv("STORAGE_PRIMARY_BACKEND", "hippius").lower() != "aws_s3"
+
+    bam_path = out_dir / "input.bam"
+    truth_path = out_dir / "truth.vcf.gz"
+    mutations_path = out_dir / "mutations.vcf.gz"
+
+    # --- BAM (required) ---
+    # Reuse only if the BAM is non-empty (+ sha256 match when provided) AND its
+    # index is present — a truncated BAM or a missing index forces a redownload.
+    _bam_indexed = (Path(f"{bam_path}.bai").exists()
+                    or bam_path.with_suffix(".bam.bai").exists())
+    if _reuse_ok(bam_path, sample.get("bam_sha256")) and _bam_indexed:
+        print(f"   BAM already downloaded — reusing {bam_path.name}", flush=True)
+    else:
+        # The platform returns a primary URL and a backup URL. Use the primary
+        # by default; swap to the backup as primary only when the operator sets
+        # STORAGE_PRIMARY_BACKEND (same knob the round path honors).
+        if _prefer_hippius:
+            bam_url = sample.get("bam_presigned_url_backup") or sample.get("bam_presigned_url")
+            bam_backup = sample.get("bam_presigned_url")
+        else:
+            bam_url = sample.get("bam_presigned_url")
+            bam_backup = sample.get("bam_presigned_url_backup")
+        if not bam_url and not bam_backup:
+            print("   ERROR: sample has no BAM URL", flush=True)
+            return None
+        print(f"   Downloading BAM...", flush=True)
+        primary, backup = _coalesce_urls(bam_url, bam_backup)
+        got = download_file_with_fallback(
+            primary, bam_path, backup_url=backup,
+            expected_sha256=sample.get("bam_sha256"), show_progress=True,
+        )
+        if not got or not got.exists():
+            print("   ERROR: failed to download BAM", flush=True)
+            return None
+        # BAM index — best-effort; hap.py/GATK need it, but we can build it
+        # locally if the download slot is absent or fails.
+        bam_index = Path(str(bam_path) + ".bai")
+        _download_index_best_effort(
+            sample.get("bam_index_presigned_url"),
+            sample.get("bam_index_presigned_url_backup"),
+            bam_index,
+        )
+        if not bam_index.exists():
+            if not _ensure_bam_index(bam_path):
+                return None
+
+    # --- Truth VCF (required) ---
+    # Reuse only if the file is non-empty AND (when the sample carries a
+    # sha256) matches it — a truncated file from an interrupted prior run must
+    # NOT be silently reused, or the self-score is wrong.
+    if _reuse_ok(truth_path, sample.get("truth_vcf_sha256")):
+        print(f"   Truth already downloaded — reusing {truth_path.name}", flush=True)
+    else:
+        truth_url = sample.get("truth_vcf_presigned_url")
+        truth_backup = sample.get("truth_vcf_presigned_url_backup")
+        if not truth_url and not truth_backup:
+            print("   ERROR: sample has no truth VCF URL", flush=True)
+            return None
+        print(f"   Downloading truth VCF...", flush=True)
+        primary, backup = _coalesce_urls(truth_url, truth_backup)
+        got = download_file_with_fallback(
+            primary, truth_path, backup_url=backup,
+            expected_sha256=sample.get("truth_vcf_sha256"), show_progress=True,
+        )
+        if not got or not got.exists():
+            print("   ERROR: failed to download truth VCF", flush=True)
+            return None
+        # Truth index (.tbi) — nice to have; hap.py can build it if absent
+        _download_index_best_effort(
+            sample.get("truth_vcf_index_presigned_url"),
+            sample.get("truth_vcf_index_presigned_url_backup"),
+            Path(str(truth_path) + ".tbi"),
+        )
+
+    # --- Mutations VCF (optional but strongly recommended) ---
+    # Verify its sha256 like the BAM and truth — the validator downloads the
+    # mutations VCF with the same checksum, and it defines the scoring scope,
+    # so a corrupt copy would silently change the score.
+    have_mutations = False
+    if _reuse_ok(mutations_path, sample.get("mutations_vcf_sha256")):
+        print(f"   Mutations already downloaded — reusing {mutations_path.name}", flush=True)
+        have_mutations = True
+    else:
+        mut_url = sample.get("mutations_vcf_presigned_url")
+        mut_backup = sample.get("mutations_vcf_presigned_url_backup")
+        if mut_url or mut_backup:
+            print(f"   Downloading mutations VCF...", flush=True)
+            primary, backup = _coalesce_urls(mut_url, mut_backup)
+            got = download_file_with_fallback(
+                primary, mutations_path, backup_url=backup,
+                expected_sha256=sample.get("mutations_vcf_sha256"), show_progress=True,
+            )
+            if got and got.exists():
+                have_mutations = True
+                _download_index_best_effort(
+                    sample.get("mutations_vcf_index_presigned_url"),
+                    sample.get("mutations_vcf_index_presigned_url_backup"),
+                    Path(str(mutations_path) + ".tbi"),
+                )
+
+    return {
+        "bam": bam_path,
+        "truth": truth_path,
+        "mutations": mutations_path if have_mutations else None,
+        "dir": out_dir,
+    }
+
+
+async def run_practice(cfg) -> int:
+    """Interactive practice mode: pick a sample, download it, run + self-score.
+
+    No chain. Uses an ephemeral keypair against the platform's /v2/practice/*
+    namespace (which the platform 404s unless practice mode is enabled). The
+    run+score core is shared with --score via _run_and_score().
+    """
+    tool = (getattr(cfg, "variant_caller", None) or os.getenv("MINER_TEMPLATE") or "gatk").lower()
+
+    try:
+        require_docker()
+    except RuntimeError as e:
+        print(f"ERROR: {e}", flush=True)
+        return 2
+
+    platform_url = os.getenv("PLATFORM_URL", "")
+    if not platform_url:
+        print("ERROR: PLATFORM_URL not set — required for practice mode.", flush=True)
+        return 2
+
+    keypair = Keypair.create_from_uri(f"//practice-{secrets.token_hex(4)}")
+    try:
+        # PlatformClient.__init__ raises ValueError for a non-https,
+        # non-localhost PLATFORM_URL — catch it here so a misconfigured URL
+        # prints a clean error instead of a raw traceback.
+        client = MinerPlatformClient(
+            keypair=keypair,
+            config=PlatformConfig(base_url=platform_url,
+                                  timeout=float(os.getenv("PLATFORM_TIMEOUT", "60"))),
+            demo=False,
+        )
+    except ValueError as e:
+        print(f"ERROR: invalid PLATFORM_URL: {e}", flush=True)
+        return 2
+
+    _UI.banner(tool)
+
+    # --- Fetch the sample menu ---
+    try:
+        listing = await client.list_practice_samples()
+    except PlatformClientError as e:
+        _UI.info(f"[red]ERROR:[/] {e}" if _UI.console else f"ERROR: {e}")
+        return 1
+    samples = listing.get("samples", [])
+    if not samples:
+        _UI.info("No practice samples available on this platform.")
+        return 1
+
+    # Flags let a caller shortcut the menus (non-interactive use):
+    #   --config X  -> action defaults to "score" (with that config)
+    #   --sample_id -> that sample, single-shot
+    flag_sample_id = getattr(cfg, "sample_id", None)
+    flag_config = cfg.config
+    single_shot = bool(flag_sample_id)
+
+    async def _fetch_and_download(sample_id):
+        """Fetch a sample's URLs and download its files. Returns files dict or None."""
+        print(f"\n   Fetching '{sample_id}'...", flush=True)
+        try:
+            full = await client.get_practice_sample(sample_id)
+        except PlatformClientError as e:
+            print(f"   ERROR: {e}", flush=True)
+            return None
+        files = _download_practice_files(full)
+        if files is None:
+            return None
+        return full, files
+
+    def _score_one(full, files, score_tool, score_config_src):
+        """Resolve ref+SDF and score one downloaded sample with the given tool/config."""
+        region = full.get("region")
+        chrom = region.split(":")[0] if region else "chr20"
+        ref_path = _resolve_reference_for(chrom)
+        if ref_path is None:
+            print(f"   ERROR: reference not found for {chrom}. "
+                  f"Place it at datasets/reference/{chrom}/{chrom}.fa", flush=True)
+            return False
+        if not _ensure_fasta_index(ref_path):
+            return False
+        try:
+            tool_config = _load_config_for_scoring(score_config_src, score_tool)
+        except (FileNotFoundError, ValueError, json.JSONDecodeError) as e:
+            print(f"   ERROR: could not load config: {e}", flush=True)
+            return False
+        opts = tool_config.get(f"{score_tool}_options", {})
+        cfg_name = score_config_src or f'configs/{score_tool}.conf'
+        _UI.info(f"[cyan]Scoring[/] with tool=[bold]{score_tool}[/], config=[bold]{cfg_name}[/]  [dim]({len(opts)} params)[/]"
+                 if _UI.console else f"Scoring with tool={score_tool}, config={cfg_name}  ({len(opts)} params)")
+        if files["mutations"] is None:
+            _UI.info("[yellow]NOTE:[/] no mutations VCF for this sample — score may differ slightly from the validator."
+                     if _UI.console else "NOTE: no mutations VCF for this sample — score may differ slightly from the validator.")
+        # _run_and_score returns the combined_final on success, or None if the
+        # variant caller, hap.py, SDF resolution, or scoring failed. Surface
+        # that as the outcome so a failed score is reported as failure (and a
+        # single-shot / --demo run exits non-zero) instead of a false success.
+        result = _run_and_score(
+            tool=score_tool,
+            tool_config=tool_config,
+            bam_path=files["bam"],
+            ref_path=ref_path,
+            truth_path=files["truth"],
+            mutations_path=files["mutations"],
+            region=region,
+        )
+        if result is None:
+            print("   ERROR: scoring did not complete — see the messages above.", flush=True)
+            return False
+        return True
+
+    def _plain_action(_choices):
+        print("\n   What do you want to do?", flush=True)
+        print("     1. Score  — run your config on a sample and see your score", flush=True)
+        print("     2. Download — just fetch sample files (BAM + truth + mutations)", flush=True)
+        raw = input("\n   Pick 1 or 2 (or 'q' to quit): ").strip().lower()
+        if raw in ("q", "quit", "exit"):
+            return None
+        if raw in ("1", "score", "s"):
+            return "score"
+        if raw in ("2", "download", "d"):
+            return "download"
+        return "__invalid__"
+
+    while True:
+        # --- Step 1: choose the action (score or download) ---
+        if flag_config or single_shot:
+            action = "score"
+        else:
+            try:
+                action = await _UI.select(
+                    "What do you want to do?",
+                    [("Score — run your config and see your score", "score"),
+                     ("Download — just fetch a sample's files", "download")],
+                    _plain_action,
+                )
+            except EOFError:
+                return 0
+            if action is None:
+                return 0
+            if action == "__invalid__":
+                _UI.info("Invalid selection.")
+                continue
+
+        # --- Step 1b (score only): confirm the tool (default .env MINER_TEMPLATE) ---
+        run_tool = tool
+        if action == "score" and not single_shot and not flag_config:
+            try:
+                run_tool = await _UI.confirm_tool(tool)
+            except EOFError:
+                return 0
+            if not run_tool:
+                return 0
+
+        # --- Step 2: choose the sample (with an 'all' option for download) ---
+        allow_all = (action == "download")
+        if flag_sample_id:
+            match = next((s for s in samples if s.get("sample_id") == flag_sample_id), None)
+            if not match:
+                _UI.info(f"ERROR: sample_id '{flag_sample_id}' not in menu: "
+                         f"{[s.get('sample_id') for s in samples]}")
+                return 1
+            chosen = [flag_sample_id]
+        else:
+            def _plain_sample(_choices):
+                _UI.sample_table(samples, allow_all)
+                prompt = ("\n   Pick a sample number"
+                          + (" or 'a' for all" if allow_all else "")
+                          + " (or 'q' to quit): ")
+                raw = input(prompt).strip().lower()
+                if raw in ("q", "quit", "exit"):
+                    return None
+                if allow_all and raw in ("a", "all"):
+                    return "__all__"
+                if raw.isdigit() and 1 <= int(raw) <= len(samples):
+                    return samples[int(raw) - 1]["sample_id"]
+                return "__invalid__"
+
+            # Interactive: a rich table for context, then an arrow-key picker.
+            if _UI.interactive and _UI.questionary:
+                _UI.sample_table(samples, allow_all=False)
+            choices = [
+                (f"{s.get('sample_id')}  ·  {s.get('chromosome')}  ·  {s.get('num_mutations')} mutations",
+                 s["sample_id"])
+                for s in samples
+            ]
+            if allow_all:
+                choices.append(("ALL — download every sample", "__all__"))
+            try:
+                picked = await _UI.select("Pick a sample:", choices, _plain_sample)
+            except EOFError:
+                return 0
+            if picked is None:
+                return 0
+            if picked == "__invalid__":
+                _UI.info("Invalid selection.")
+                continue
+            chosen = [s["sample_id"] for s in samples] if picked == "__all__" else [picked]
+
+        # --- Act on each chosen sample ---
+        for sid in chosen:
+            result = await _fetch_and_download(sid)
+            if result is None:
+                if single_shot:
+                    return 1
+                continue
+            full, files = result
+            if action == "download":
+                if _UI.console:
+                    _UI.console.print(f"   [green]✓[/] Downloaded [bold]{sid}[/] → [dim]{files['dir']}[/]")
+                    _UI.console.print(f"       [dim]BAM[/] {files['bam'].name}   [dim]truth[/] {files['truth'].name}"
+                                      + (f"   [dim]mutations[/] {files['mutations'].name}" if files['mutations'] else ""))
+                else:
+                    print(f"   Downloaded '{sid}' to {files['dir']}", flush=True)
+                    print(f"     BAM:       {files['bam']}", flush=True)
+                    print(f"     Truth:     {files['truth']}", flush=True)
+                    print(f"     Mutations: {files['mutations'] if files['mutations'] else '(none)'}", flush=True)
+            else:
+                ok = _score_one(full, files, run_tool, flag_config)
+                if not ok and single_shot:
+                    return 1
+
+        # --- Loop unless a flag forced a single-shot run ---
+        if single_shot or flag_config:
+            return 0
+        try:
+            if _UI.interactive and _UI.questionary:
+                again = bool(await _UI.questionary.confirm("Do another?", default=False, style=_UI._qstyle).ask_async())
+            else:
+                again = input("\n   Do another? [y/N]: ").strip().lower() in ("y", "yes")
+        except EOFError:
+            return 0
+        if not again:
+            if _UI.console:
+                _UI.console.print("\n   [dim]Done. Happy tuning![/]\n")
+            return 0
+
+
+def _parse_side_mode_args(argv):
+    """Parse --score / --practice / --demo and their sub-args from raw argv.
+
+    bittensor's bt.config() does NOT surface plain store_true flags like
+    --practice/--score/--demo as top-level config attributes (and it has its
+    OWN --config flag that collides with ours), so we must NOT rely on the
+    bittensor Config for these. Parse them from sys.argv directly with a
+    plain argparse that ignores everything else. Returns a namespace with
+    .score/.practice/.demo and the sub-args (bam/truth/region/config/etc.).
+    """
+    p = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+    p.add_argument("--score", action="store_true", default=False)
+    p.add_argument("--practice", action="store_true", default=False)
+    p.add_argument("--demo", action="store_true", default=False)
+    p.add_argument("--bam", type=str, default=None)
+    p.add_argument("--truth", type=str, default=None)
+    p.add_argument("--mutations", type=str, default=None)
+    p.add_argument("--region", type=str, default=None)
+    p.add_argument("--config", type=str, default=None)
+    p.add_argument("--reference", type=str, default=None)
+    p.add_argument("--confident_bed", type=str, default=None)
+    p.add_argument("--reference_sdf", type=str, default=None)
+    p.add_argument("--sample_id", type=str, default=None)
+    p.add_argument("--variant_caller", type=str, default=None)
+    ns, _unknown = p.parse_known_args(argv)
+    return ns
+
+
+# Default sample --demo scores against. Env-overridable so ops can rotate it
+# without a code change. A one-shot onboarding run: --demo is just the practice
+# self-scorer pinned to this single fixed sample (no picker).
+DEMO_SAMPLE_ID = os.getenv("DEMO_SAMPLE_ID", "d7b99f4a-061c-4202-8b12-2c1425bd4974")
+
+
 def main():
     """Main entry point."""
-    miner = Miner()
+    # Detect side-modes from raw argv BEFORE bittensor's config layer (which
+    # drops these custom flags). --score/--practice/--demo bypass the full miner.
+    side = _parse_side_mode_args(sys.argv[1:])
+    if side.score:
+        sys.exit(run_offline_score(side))
+    if side.demo:
+        # --demo == the practice self-scorer pinned to one fixed sample: no
+        # chain/wallet, download BAM + truth, run the config, print the exact
+        # score a validator would compute. Pin the sample and default the
+        # config so a brand-new operator gets a score in one command.
+        side.practice = True
+        if not getattr(side, "sample_id", None):
+            side.sample_id = DEMO_SAMPLE_ID
+        if not getattr(side, "config", None):
+            tool = side.variant_caller or os.getenv("MINER_TEMPLATE") or "gatk"
+            side.config = f"configs/{tool}.conf"
+    if side.practice:
+        # Ephemeral keypair + /v2/practice/*; no chain/wallet/metagraph.
+        sys.exit(asyncio.run(run_practice(side)))
+
+    cfg = Miner.get_config()
+    miner = Miner(config=cfg)
     miner.run()
 
 

--- a/pm2-miner.sh
+++ b/pm2-miner.sh
@@ -1,38 +1,33 @@
 #!/usr/bin/env bash
-# Start or restart the miner under PM2 (wraps start-miner.sh).
+# Start or restart the LIVE miner under PM2 (wraps start-miner.sh).
 #
 # Usage:
 #   bash pm2-miner.sh          # live mode (uses .env wallet)
-#   bash pm2-miner.sh --demo   # demo sandbox (no wallet, ephemeral keypair)
 #
-# --demo here just exports MINER_DEMO=true before PM2 takes over; the
-# Python miner reads the env var at startup. To make demo mode persist
-# across restarts add MINER_DEMO=true to your .env instead.
+# PM2 is for the long-running live miner only. Demo/practice are one-shot
+# scoring tools that run once and exit — run those in the foreground
+# (`bash start-miner.sh --demo` / `--practice`), NOT under a process
+# supervisor, which would restart-loop them.
 set -euo pipefail
 cd "$(dirname "$0")"
-
-DEMO=false
 
 usage() {
   cat <<'EOF'
 Usage: bash pm2-miner.sh [OPTIONS]
 
+Runs the LIVE miner under PM2. For a one-shot scored test run without a
+wallet, use: bash start-miner.sh --demo  (or --practice).
+
 Options:
-  --demo       Run the miner under PM2 in demo mode.
   --help, -h   Show this help.
 
 Examples:
   bash pm2-miner.sh
-  bash pm2-miner.sh --demo
 EOF
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --demo)
-      DEMO=true
-      shift
-      ;;
     --help|-h)
       usage
       exit 0
@@ -56,11 +51,6 @@ if ! command -v pm2 &>/dev/null; then
   echo "The installer repairs Node/npm, installs PM2, and reports any PATH fix needed." >&2
   echo "Manual fallback: npm install -g pm2" >&2
   exit 1
-fi
-
-if [[ "$DEMO" == "true" ]]; then
-  echo "Launching minos-miner under PM2 in DEMO mode (MINER_DEMO=true)"
-  export MINER_DEMO=true
 fi
 
 if pm2 describe minos-miner &>/dev/null; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
+# Install the CPU build of PyTorch by default (much smaller than the CUDA
+# build). For GPU, install torch from pytorch.org first, then run this file.
+--extra-index-url https://download.pytorch.org/whl/cpu
 bittensor>=9.12.2
 bittensor-cli>=9.5.0
-torch>=2.0.0
+torch>=2.0.0,<2.7.0
 numpy>=1.24.0
 pydantic>=2.0.0
 python-dotenv>=1.0.0

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 # Minos Subnet 107 — Interactive Demo
-# Runs a single demo round end-to-end so a new miner can verify
-# that their variant-calling pipeline works before going live.
+# Runs a one-shot demo end-to-end so a new miner can verify their
+# variant-calling pipeline works — and see the score it earns — before
+# going live.
 #
 # What happens:
 #   1. Runs verify.sh to check prerequisites (Docker, Python, etc.)
 #   2. Ensures a .env file exists (creates a temporary demo one if not)
-#   3. Starts the miner, which connects to the platform in demo mode
-#   4. The miner downloads a BAM file, runs your chosen variant caller,
-#      and attempts to submit — the platform responds with "demo complete"
-#   5. This script inspects the output VCF and prints a summary
+#   3. Starts the miner with --demo (no wallet, no chain)
+#   4. The miner downloads a fixed, fully-answered sample (BAM + truth),
+#      runs your chosen variant caller, and self-scores it
+#   5. It prints the exact score a validator would give your config
 #
 # Usage: bash scripts/demo.sh [--template gatk|deepvariant|bcftools]
 #        Run from the minos_subnet/ directory.
@@ -48,7 +49,7 @@ while [[ $# -gt 0 ]]; do
         -h|--help)
             echo "Usage: bash scripts/demo.sh [--template gatk|deepvariant|bcftools]"
             echo ""
-            echo "Runs a single demo round to verify your miner setup."
+            echo "Runs a one-shot demo that scores your config to verify your miner setup."
             echo "If --template is not specified, the value from .env is used (default: gatk)."
             exit 0
             ;;
@@ -80,15 +81,15 @@ echo -e "${BOLD}================================================================
 echo -e "${BOLD}  Minos SN107 — Demo Round${NC}"
 echo -e "${BOLD}================================================================${NC}"
 echo ""
-echo -e "  This script runs a ${CYAN}single demo round${NC} end-to-end so you can"
-echo -e "  confirm that your miner setup works before going live."
+echo -e "  This script runs a ${CYAN}one-shot demo${NC} end-to-end so you can confirm"
+echo -e "  your miner setup works — and see its score — before going live."
 echo ""
 echo -e "  What will happen:"
 echo -e "    1. Verify prerequisites (Docker, Python packages)"
 echo -e "    2. Start the miner with ${CYAN}--demo${NC} — no wallet needed, no chain conn."
-echo -e "    3. The miner connects to ${CYAN}https://api.theminos.ai/v2/demo/*${NC}"
-echo -e "    4. It downloads a sandbox BAM and runs your variant caller"
-echo -e "    5. Results are displayed here with a score estimate"
+echo -e "    3. It downloads a fixed, fully-answered sample (BAM + truth)"
+echo -e "    4. It runs your variant caller on the sample"
+echo -e "    5. It prints the exact score a validator would give your config"
 echo ""
 echo -e "  ${YELLOW}Estimated time: 3-30 minutes${NC} (depends on your machine and"
 echo -e "  the variant caller — bcftools is fastest, DeepVariant slowest)"
@@ -99,7 +100,7 @@ echo ""
 # ---------------------------------------------------------------------------
 # Step 1: Run verify.sh
 # ---------------------------------------------------------------------------
-echo -e "${BOLD}--- Step 1/4: Verifying prerequisites ---${NC}"
+echo -e "${BOLD}--- Step 1/3: Verifying prerequisites ---${NC}"
 echo ""
 
 if [[ ! -f "$SCRIPT_DIR/verify.sh" ]]; then
@@ -120,7 +121,7 @@ echo ""
 # ---------------------------------------------------------------------------
 # Step 2: Ensure .env exists
 # ---------------------------------------------------------------------------
-echo -e "${BOLD}--- Step 2/4: Checking configuration ---${NC}"
+echo -e "${BOLD}--- Step 2/3: Checking configuration ---${NC}"
 echo ""
 
 CREATED_TEMP_ENV=false
@@ -186,217 +187,38 @@ trap cleanup EXIT
 # ---------------------------------------------------------------------------
 # Step 3: Run the miner and capture output
 # ---------------------------------------------------------------------------
-echo -e "${BOLD}--- Step 3/4: Running demo round ---${NC}"
+echo -e "${BOLD}--- Step 3/3: Scoring your config ---${NC}"
 echo ""
 echo -e "  Starting miner with template ${CYAN}$ACTIVE_TEMPLATE${NC}..."
-echo -e "  The miner will poll the platform for the demo round, download"
-echo -e "  a BAM file, and run variant calling inside Docker."
+echo -e "  The miner will download a fixed, fully-answered sample, run variant"
+echo -e "  calling inside Docker, and self-score the result against truth."
 echo ""
 echo -e "  ${YELLOW}You will see miner logs below. This may take several minutes.${NC}"
-echo -e "  ${YELLOW}The demo ends automatically after one round completes.${NC}"
+echo -e "  ${YELLOW}It ends automatically once your score is printed.${NC}"
 echo ""
 echo -e "  ---- miner output begin ----"
 echo ""
 
-# We run the miner and watch for the demo-complete signal.
-# The miner runs forever in a polling loop, so we need to kill it
-# once we see it has completed the demo round.
-#
-# Strategy: run the miner in background, tail its output, and kill it
-# once we see the "DEMO COMPLETE" or "demo mode" banner, or after
-# a timeout.
-
-DEMO_LOG="$PROJECT_DIR/.demo_output.log"
-DEMO_TIMEOUT=1800  # 30 minutes max
-DEMO_PID=""
-
-# Clean up any previous log
-rm -f "$DEMO_LOG"
-
-# Resolve venv Python
-PYTHON="python3"
-if [[ -f "$PROJECT_DIR/.venv/bin/python3" ]]; then
-    PYTHON="$PROJECT_DIR/.venv/bin/python3"
-fi
-
-# Run the miner in the background, capturing output. --demo routes the
-# client to /v2/demo/* (no wallet required, no chain connection) so the
-# script works even if the user hasn't run setup.py / has no registered
-# hotkey. Demo path is sandboxed: no submissions are persisted, no TAO
-# is earned — purely a pipeline-test loop.
+# Delegate to start-miner.sh --demo. That is the single place that prepares
+# everything scoring needs — Docker images, the chr20 reference, AND the RTG
+# SDF (required by vcfeval) — before exec'ing the one-shot scorer. Running the
+# miner directly here would skip the SDF fetch and fail on a fresh box.
+DEMO_RC=0
 (
     cd "$PROJECT_DIR"
-    $PYTHON -m neurons.miner --demo 2>&1
-) > "$DEMO_LOG" 2>&1 &
-DEMO_PID=$!
-
-# Also clean up child process on exit
-cleanup_all() {
-    if [[ -n "$DEMO_PID" ]] && kill -0 "$DEMO_PID" 2>/dev/null; then
-        kill "$DEMO_PID" 2>/dev/null || true
-        wait "$DEMO_PID" 2>/dev/null || true
-    fi
-    rm -f "$DEMO_LOG"
-    cleanup
-}
-trap cleanup_all EXIT
-
-# Follow the log in real time, watching for completion signals
-SECONDS_WAITED=0
-DEMO_COMPLETE=false
-LAST_LINE=0
-
-while [[ $SECONDS_WAITED -lt $DEMO_TIMEOUT ]]; do
-    # Check if miner process is still running
-    if ! kill -0 "$DEMO_PID" 2>/dev/null; then
-        # Process ended — print remaining output
-        if [[ -f "$DEMO_LOG" ]]; then
-            tail -n +$((LAST_LINE + 1)) "$DEMO_LOG" 2>/dev/null || true
-        fi
-        break
-    fi
-
-    # Print new lines from the log
-    if [[ -f "$DEMO_LOG" ]]; then
-        NEW_LINES=$(wc -l < "$DEMO_LOG" 2>/dev/null || echo 0)
-        if [[ "$NEW_LINES" -gt "$LAST_LINE" ]]; then
-            tail -n +$((LAST_LINE + 1)) "$DEMO_LOG" | head -n $((NEW_LINES - LAST_LINE))
-            LAST_LINE=$NEW_LINES
-        fi
-
-        # Check for demo completion signals
-        if grep -q "DEMO COMPLETE" "$DEMO_LOG" 2>/dev/null; then
-            DEMO_COMPLETE=true
-            sleep 2  # Let the miner finish printing
-            # Print any final lines
-            NEW_LINES=$(wc -l < "$DEMO_LOG" 2>/dev/null || echo 0)
-            if [[ "$NEW_LINES" -gt "$LAST_LINE" ]]; then
-                tail -n +$((LAST_LINE + 1)) "$DEMO_LOG" | head -n $((NEW_LINES - LAST_LINE))
-            fi
-            break
-        fi
-
-        # Also check for errors that indicate the round was processed
-        if grep -q "Total rounds participated: 1" "$DEMO_LOG" 2>/dev/null; then
-            DEMO_COMPLETE=true
-            sleep 2
-            NEW_LINES=$(wc -l < "$DEMO_LOG" 2>/dev/null || echo 0)
-            if [[ "$NEW_LINES" -gt "$LAST_LINE" ]]; then
-                tail -n +$((LAST_LINE + 1)) "$DEMO_LOG" | head -n $((NEW_LINES - LAST_LINE))
-            fi
-            break
-        fi
-    fi
-
-    sleep 2
-    SECONDS_WAITED=$((SECONDS_WAITED + 2))
-done
+    bash start-miner.sh --demo
+) || DEMO_RC=$?
 
 echo ""
 echo -e "  ---- miner output end ----"
 echo ""
 
-# Kill the miner if it is still running
-if [[ -n "$DEMO_PID" ]] && kill -0 "$DEMO_PID" 2>/dev/null; then
-    kill "$DEMO_PID" 2>/dev/null || true
-    wait "$DEMO_PID" 2>/dev/null || true
-fi
-
-# Check what happened
-if [[ $SECONDS_WAITED -ge $DEMO_TIMEOUT ]]; then
-    echo -e "  ${RED}[TIMEOUT]${NC} Demo did not complete within $((DEMO_TIMEOUT / 60)) minutes."
-    echo -e "  This might mean:"
-    echo -e "    - No demo round is currently active on the platform"
-    echo -e "    - Docker is slow to start on your machine"
-    echo -e "    - The variant caller hit an error"
-    echo ""
-    echo -e "  Check the full log: ${CYAN}$DEMO_LOG${NC}"
-    echo -e "  Or try running the miner directly:"
-    echo -e "    cd $PROJECT_DIR && bash start-miner.sh"
+if [[ $DEMO_RC -ne 0 ]]; then
+    echo -e "  ${RED}[FAIL]${NC} Demo run exited with an error (code $DEMO_RC)."
+    echo -e "  Check the output above for the cause (Docker, reference data, or"
+    echo -e "  variant-caller error). You can retry with:"
+    echo -e "    cd $PROJECT_DIR && bash start-miner.sh --demo"
     exit 1
-fi
-
-# ---------------------------------------------------------------------------
-# Step 4: Inspect results
-# ---------------------------------------------------------------------------
-echo -e "${BOLD}--- Step 4/4: Results summary ---${NC}"
-echo ""
-
-# Find the most recent output VCF in the working directory
-VCF_FILE=""
-ROUND_DIR=""
-
-# The miner writes output to output/<round_id>/output.vcf.gz
-if [[ -d "$PROJECT_DIR/output" ]]; then
-    # Find the newest output.vcf.gz
-    VCF_FILE=$(find "$PROJECT_DIR/output" -name "output.vcf.gz" -type f -newer "$DEMO_LOG" 2>/dev/null | head -1 || true)
-    if [[ -z "$VCF_FILE" ]]; then
-        # Fallback: find any output.vcf.gz, sorted by time
-        VCF_FILE=$(find "$PROJECT_DIR/output" -name "output.vcf.gz" -type f 2>/dev/null | xargs ls -t 2>/dev/null | head -1 || true)
-    fi
-fi
-
-if [[ -n "$VCF_FILE" && -f "$VCF_FILE" ]]; then
-    ROUND_DIR="$(dirname "$VCF_FILE")"
-    VCF_SIZE=$(du -h "$VCF_FILE" | cut -f1)
-
-    echo -e "  ${GREEN}[OK]${NC} Output VCF found: $VCF_FILE ($VCF_SIZE)"
-    echo ""
-
-    # Count variants
-    VARIANT_COUNT=0
-    SNP_COUNT=0
-    INDEL_COUNT=0
-
-    if command -v zcat &>/dev/null || command -v gzcat &>/dev/null; then
-        # macOS uses gzcat, Linux uses zcat
-        ZCAT="zcat"
-        if [[ "$(uname)" == "Darwin" ]]; then
-            ZCAT="gzcat"
-        fi
-
-        VARIANT_COUNT=$($ZCAT "$VCF_FILE" 2>/dev/null | grep -v "^#" | wc -l | tr -d ' ' || echo 0)
-
-        # Count SNPs vs INDELs (SNP = REF and ALT are both single chars)
-        SNP_COUNT=$($ZCAT "$VCF_FILE" 2>/dev/null | grep -v "^#" | awk 'length($4)==1 && length($5)==1' | wc -l | tr -d ' ' || echo 0)
-        INDEL_COUNT=$((VARIANT_COUNT - SNP_COUNT))
-
-        echo -e "  ${BOLD}Variant Summary:${NC}"
-        echo -e "    Total variants: ${CYAN}$VARIANT_COUNT${NC}"
-        echo -e "    SNPs:           ${CYAN}$SNP_COUNT${NC}"
-        echo -e "    INDELs:         ${CYAN}$INDEL_COUNT${NC}"
-        echo ""
-
-        # Show first 10 data lines
-        echo -e "  ${BOLD}First 10 variant calls:${NC}"
-        echo ""
-        $ZCAT "$VCF_FILE" 2>/dev/null | grep -v "^#" | head -10 | while IFS=$'\t' read -r CHROM POS ID REF ALT QUAL FILTER REST; do
-            # Determine variant type
-            if [[ ${#REF} -eq 1 && ${#ALT} -eq 1 ]]; then
-                VTYPE="SNP"
-            else
-                VTYPE="INDEL"
-            fi
-            printf "    %-6s %-12s %s>%s  QUAL=%-8s %s\n" "$CHROM" "$POS" "$REF" "$ALT" "$QUAL" "$VTYPE"
-        done
-        echo ""
-
-        if [[ $VARIANT_COUNT -gt 10 ]]; then
-            echo -e "    ... and $((VARIANT_COUNT - 10)) more variants"
-            echo ""
-        fi
-    else
-        echo -e "  ${YELLOW}[WARN]${NC} Cannot decompress VCF (zcat/gzcat not found)"
-        echo -e "  File exists at: $VCF_FILE"
-    fi
-else
-    if [[ "$DEMO_COMPLETE" == "true" ]]; then
-        echo -e "  ${YELLOW}[INFO]${NC} Demo round completed but no VCF file found."
-        echo -e "  The demo round may have been a connectivity-only test."
-    else
-        echo -e "  ${RED}[FAIL]${NC} No output VCF found. The variant caller may have failed."
-        echo -e "  Check the miner logs above for error messages."
-    fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -466,11 +288,7 @@ echo -e "     Dashboard: ${CYAN}https://app.theminos.ai${NC}"
 echo ""
 echo -e "${BOLD}================================================================${NC}"
 
-if [[ "$DEMO_COMPLETE" == "true" ]]; then
-    echo -e "  ${GREEN}Demo completed successfully. Your miner is ready!${NC}"
-else
-    echo -e "  ${YELLOW}Demo finished (check output above for any issues).${NC}"
-fi
+echo -e "  ${GREEN}Demo completed successfully. Your miner is ready!${NC}"
 
 echo -e "${BOLD}================================================================${NC}"
 echo ""

--- a/setup.py
+++ b/setup.py
@@ -430,16 +430,16 @@ class SetupWizard:
         if role == "demo-miner":
             # Demo branch reuses all the miner steps (template, Docker images,
             # reference data, env, process mgmt) but skips wallet setup and
-            # writes a MINER_DEMO=true env so start-miner.sh routes to the
-            # platform's /v2/demo/* sandbox.
+            # writes a MINER_DEMO=true env so start-miner.sh runs the one-shot
+            # self-scorer (--practice pinned to a fixed sample) with no wallet.
             self.state.role = "miner"
             self.state.is_demo = True
             self.state.wallet_name = "demo"
             self.state.wallet_hotkey = "demo"
-            self.console.print("  [green]✓[/] Role: [bold green]Demo miner[/] — test the pipeline only")
+            self.console.print("  [green]✓[/] Role: [bold green]Demo miner[/] — score your config on a fixed sample")
             self.console.print(
-                "  [dim]No wallet will be created; the miner uses an ephemeral "
-                "keypair against /v2/demo/* — no TAO, no scoring.[/]"
+                "  [dim]No wallet required. Downloads a fully-answered sample, "
+                "runs your config, and prints the score a validator would give it.[/]"
             )
         else:
             self.state.role = role
@@ -1036,7 +1036,7 @@ class SetupWizard:
 
         files = MINER_DATA_FILES if self.state.role == "miner" else VALIDATOR_DATA_FILES
 
-        # Demo mode only ever scores against the static chr20 demo BAM
+        # Demo mode only ever runs the caller against a single chr20 demo BAM
         # (see DEMO_REGION in platform .env.example). Downloading 22
         # chromosomes' worth of reference data for a pipeline smoke test
         # would burn ~3.9 GB of bandwidth and disk for no reason.
@@ -1186,8 +1186,9 @@ class SetupWizard:
             env["MINER_TEMPLATE"] = self.state.template
 
         if self.state.is_demo:
-            # start-miner.sh checks MINER_DEMO; the miner --demo flag also
-            # reads this env var. Both paths end up routing to /v2/demo/*.
+            # start-miner.sh treats MINER_DEMO=true as demo intent and runs the
+            # one-shot self-scorer (--practice pinned to a fixed sample), same
+            # as the --demo flag.
             env["MINER_DEMO"] = "true"
 
         # Build .env content
@@ -1870,8 +1871,16 @@ if __name__ == "__main__":
 
         # Truthy MINER_DEMO narrows reference data to chr20 and Docker images
         # to the chosen template only, matching the wizard's demo-miner branch.
-        if env_vars.get("MINER_DEMO", "").strip().lower() in ("1", "true", "yes", "on"):
+        # Read from the .env FILE first, then fall back to the process env /
+        # a --demo argv flag so a fresh-box `bash start-miner.sh --demo` (which
+        # runs this before any .env exists) still gets the narrow chr20 scope.
+        _demo_env = env_vars.get("MINER_DEMO", "") or os.environ.get("MINER_DEMO", "")
+        if _demo_env.strip().lower() in ("1", "true", "yes", "on") or "--demo" in sys.argv:
             wizard.state.is_demo = True
+            # With no .env at all, role would default to 'validator' (superset)
+            # above; a demo run only needs the miner scope, so correct it here.
+            if not env_vars:
+                wizard.state.role = "miner"
 
         scope = "demo " if wizard.state.is_demo else ""
         print(f"\n  Updating {scope}{wizard.state.role} Docker images and reference data...\n")

--- a/start-miner.sh
+++ b/start-miner.sh
@@ -15,6 +15,9 @@ FLAG_WALLET_HOTKEY=""
 FLAG_MINER_TEMPLATE=""
 FLAG_STORAGE=""
 FLAG_DEMO=false
+FLAG_PRACTICE=false
+FLAG_PRACTICE_CONFIG=""
+FLAG_PRACTICE_SAMPLE_ID=""
 FLAG_SETUP_DITTO=false
 FLAG_SETUP_AI_ASSISTANT=false
 RUN_SETUP=false
@@ -28,8 +31,15 @@ show_help() {
     echo "  --wallet-hotkey <name>      Hotkey name"
     echo "  --miner-template <tool>     Variant caller: gatk, deepvariant, bcftools"
     echo "  --storage <backend>         Fetch order: hippius (default) or aws_s3 (R2/AWS first)"
-    echo "  --demo                      Run against the platform's /v2/demo/* sandbox"
-    echo "                              (no wallet needed, no chain connection, no TAO earned)"
+    echo "  --demo                      Score your config on a fixed sample and see your"
+    echo "                              result (no wallet, no chain). A one-shot onboarding"
+    echo "                              run: download a fully-answered sample, run your"
+    echo "                              config, print the exact score a validator would give."
+    echo "  --practice                  Interactive practice mode: pick a fully-answered"
+    echo "                              sample, run your config, and see your score"
+    echo "                              (no wallet needed, no chain connection)"
+    echo "  --config <file>             [--practice] Config file to score (default configs/gatk.conf)"
+    echo "  --sample-id <id>            [--practice] Skip the picker; use this sample directly"
     echo "  --setup-ditto               Subscribe Ditto to the public @minos knowledge graph"
     echo "  --setup-ai-assistant        Open the Minos assistant setup menu"
     echo "  --setup                     Re-run interactive setup wizard"
@@ -38,7 +48,9 @@ show_help() {
     echo "Examples:"
     echo "  bash start-miner.sh                                    # First run: interactive setup"
     echo "  bash start-miner.sh --wallet-name miner --miner-template deepvariant"
-    echo "  bash start-miner.sh --demo                             # Test pipeline without registering"
+    echo "  bash start-miner.sh --demo                             # One-shot: score your config on a fixed sample (no wallet)"
+    echo "  bash start-miner.sh --practice                         # Interactive: pick a sample and score your config"
+    echo "  bash start-miner.sh --practice --config configs/gatk.conf --sample-id <sample-id>"
     echo "  bash start-miner.sh --setup-ditto                      # Add optional Ditto @minos knowledge"
     echo "  bash start-miner.sh --setup-ai-assistant               # Choose assistant setup; MinosVM offers OpenClaw/Hermes or skip"
     echo "  bash start-miner.sh --setup                            # Re-run setup wizard"
@@ -63,6 +75,9 @@ while [[ $# -gt 0 ]]; do
         --miner-template) require_value "$1" "${2:-}"; FLAG_MINER_TEMPLATE="$2"; shift 2 ;;
         --storage) require_value "$1" "${2:-}"; FLAG_STORAGE="$2"; shift 2 ;;
         --demo) FLAG_DEMO=true; shift ;;
+        --practice) FLAG_PRACTICE=true; shift ;;
+        --config) require_value "$1" "${2:-}"; FLAG_PRACTICE_CONFIG="$2"; shift 2 ;;
+        --sample-id) require_value "$1" "${2:-}"; FLAG_PRACTICE_SAMPLE_ID="$2"; shift 2 ;;
         --setup-ditto) FLAG_SETUP_DITTO=true; shift ;;
         --setup-ai-assistant) FLAG_SETUP_AI_ASSISTANT=true; shift ;;
         --setup) RUN_SETUP=true; shift ;;
@@ -191,10 +206,11 @@ ensure_runtime_assets() {
     fi
 }
 
-# --- Compute demo intent from flag AND env var (must happen BEFORE .env is
-# sourced, so MINER_DEMO from the parent shell environment is honored even
-# when there is no .env yet — e.g. `MINER_DEMO=true bash start-miner.sh` or
-# `bash pm2-miner.sh --demo` which exports MINER_DEMO before invoking us).
+# --- Compute demo intent from flag AND env var (must happen BEFORE the
+# practice/demo fast-path and before .env is sourced, so MINER_DEMO from the
+# parent shell environment is honored even when there is no .env yet — e.g.
+# `MINER_DEMO=true bash start-miner.sh` exports MINER_DEMO before we source
+# .env).
 # Portable lowercase (works on macOS bash 3.2 — ${VAR,,} is bash 4+).
 # Accepted values match the Python miner's env parser (1|true|yes|on).
 MINER_DEMO_LC="$(printf '%s' "${MINER_DEMO:-}" | tr '[:upper:]' '[:lower:]')"
@@ -204,6 +220,98 @@ if [ "$FLAG_DEMO" = true ] || [ "$MINER_DEMO_FLAG" = true ]; then
 else
     DEMO_INTENT=false
 fi
+
+# --- Practice / demo fast-path ------------------------------------------------
+# Both --practice and --demo are one-shot scoring tools: download a
+# fully-answered sample, run the user's config, and print the exact score a
+# validator would compute. They need the venv, Docker, reference data, and
+# PLATFORM_URL — but no wallet, no .env, and no chain. Short-circuit here so
+# none of the wallet/setup machinery below runs. Honors an .env for
+# PLATFORM_URL / MINER_TEMPLATE if one exists, but does not require it.
+#
+# The only difference: --demo is pinned to a single fixed sample (no picker),
+# so a brand-new operator gets a score in one command. --practice is
+# interactive (or takes --sample-id / --config to skip the menus).
+if [ "$FLAG_PRACTICE" = true ] || [ "$DEMO_INTENT" = true ]; then
+    if [ -f .env ]; then
+        set -a; source .env; set +a
+    fi
+    : "${PLATFORM_URL:=https://api.theminos.ai}"
+    export PLATFORM_URL
+    # --miner-template wins over .env / the gatk default so a caller can pick
+    # the tool to score with in one shot, e.g. --demo --miner-template deepvariant.
+    if [ -n "$FLAG_MINER_TEMPLATE" ]; then
+        case "$FLAG_MINER_TEMPLATE" in
+            gatk|deepvariant|bcftools) MINER_TEMPLATE="$FLAG_MINER_TEMPLATE" ;;
+            *)
+                echo -e "${RED}invalid --miner-template '$FLAG_MINER_TEMPLATE'. Choose gatk, deepvariant, or bcftools.${NC}"
+                exit 1
+                ;;
+        esac
+    fi
+    export MINER_TEMPLATE="${MINER_TEMPLATE:-gatk}"
+
+    # --demo is pinned to a chr20 sample, so on a fresh box it only needs the
+    # chr20 reference. Signal demo scope to setup.py (via ensure_runtime_assets)
+    # so it fetches chr20 (~60 MB) instead of the full validator superset. Only
+    # for --demo — --practice can pick a chr21 sample and needs the wider set.
+    if [ "$DEMO_INTENT" = true ] && [ "$FLAG_PRACTICE" != true ]; then
+        export MINER_DEMO=true
+    fi
+
+    ensure_runtime_assets
+
+    # Scoring uses hap.py/vcfeval, which needs the RTG SDF — a validator-only
+    # asset the normal miner data set omits. Fetch it directly for just the
+    # sample chromosomes (chr20/chr21) — ~50 MB total, vs the ~5 GB
+    # all-chromosome validator superset. The SDF files are public.
+    REF_BASE="${REF_S3_BASE:-https://api.theminos.ai/reference}"
+    SDF_FILES="done mainIndex nameIndex0 namedata0 namepointer0 progress seqdata0 seqpointer0 sequenceIndex0 summary.txt"
+    for chrom in chr20 chr21; do
+        sdf_dir="datasets/reference/$chrom/$chrom.sdf"
+        if [ -f "$sdf_dir/seqdata0" ]; then
+            continue
+        fi
+        echo -e "${YELLOW}Fetching RTG SDF for $chrom (needed to score)...${NC}"
+        mkdir -p "$sdf_dir"
+        for f in $SDF_FILES; do
+            if ! curl -fsSL "$REF_BASE/$chrom/$chrom.sdf/$f" -o "$sdf_dir/$f"; then
+                echo -e "${RED}Could not download SDF file $chrom/$f. Scoring will fail.${NC}"
+                rm -rf "$sdf_dir"
+                exit 1
+            fi
+        done
+    done
+
+    PRACTICE_ARGS=(--practice)
+    if [ "$DEMO_INTENT" = true ]; then
+        # --demo: one-shot score on a single fixed sample (no picker). The
+        # sample id is env-overridable so ops can rotate it without a code
+        # change; the default is a chr20 sample from the practice set.
+        DEMO_SAMPLE_ID="${DEMO_SAMPLE_ID:-d7b99f4a-061c-4202-8b12-2c1425bd4974}"
+        PRACTICE_ARGS+=(--sample_id "$DEMO_SAMPLE_ID")
+        PRACTICE_ARGS+=(--config "${FLAG_PRACTICE_CONFIG:-configs/${MINER_TEMPLATE}.conf}")
+        echo -e "${GREEN}Starting Minos Miner (${MINER_TEMPLATE}) in DEMO MODE...${NC}"
+        echo -e "${GREEN}  - no wallet required, no chain connection${NC}"
+        echo -e "${GREEN}  - scores your config on a fixed sample so you can verify${NC}"
+        echo -e "${GREEN}    your pipeline works and see the number a validator gives${NC}"
+    else
+        if [ -n "$FLAG_PRACTICE_CONFIG" ]; then
+            PRACTICE_ARGS+=(--config "$FLAG_PRACTICE_CONFIG")
+        fi
+        if [ -n "$FLAG_PRACTICE_SAMPLE_ID" ]; then
+            PRACTICE_ARGS+=(--sample_id "$FLAG_PRACTICE_SAMPLE_ID")
+        fi
+        echo -e "${GREEN}Starting Minos Miner (${MINER_TEMPLATE}) in PRACTICE MODE...${NC}"
+        echo -e "${GREEN}  - no wallet required, no chain connection${NC}"
+        echo -e "${GREEN}  - pick a sample, run your config, see your score${NC}"
+    fi
+    exec python -m neurons.miner "${PRACTICE_ARGS[@]}"
+fi
+
+# Past this point demo intent has already been handled (the fast-path above
+# exec's for any --demo / MINER_DEMO invocation), so DEMO_INTENT is false here
+# and the block below is the normal wallet/chain setup path.
 
 # --- Load existing .env defaults (if any) ---
 
@@ -335,8 +443,8 @@ fi
 # --- Interactive setup (first run or --setup) ---
 # Demo-mode launches never need this — the wallet wizard would prompt
 # for a hotkey the demo miner won't use. Skip when EITHER --demo is set
-# or MINER_DEMO is truthy in the env (covers pm2-miner.sh --demo and
-# direct `MINER_DEMO=true bash start-miner.sh` invocations).
+# or MINER_DEMO is truthy in the env. (In practice demo intent is already
+# handled by the fast-path far above, which exec's; this is belt-and-braces.)
 
 if { [ ! -f .env ] || [ "$RUN_SETUP" = true ]; } && [ "$DEMO_INTENT" = false ]; then
     if [ ! -t 0 ] || [ ! -t 1 ]; then
@@ -504,12 +612,17 @@ EOF
     set -a; source .env; set +a
 fi
 
+# Demo intent may only become visible AFTER .env is sourced (a persisted
+# MINER_DEMO=true with no --demo flag and nothing exported in the shell). The
+# top-of-script fast-path runs before .env is read, so re-check here: if demo
+# is set, re-exec through the fast-path with MINER_DEMO exported so it takes
+# the demo scoring path instead of falling through to LIVE mining below (which
+# would attempt the chain with a placeholder wallet).
 MINER_DEMO_LC="$(printf '%s' "${MINER_DEMO:-}" | tr '[:upper:]' '[:lower:]')"
 case "$MINER_DEMO_LC" in 1|true|yes|on) MINER_DEMO_FLAG=true ;; *) MINER_DEMO_FLAG=false ;; esac
-if [ "$FLAG_DEMO" = true ] || [ "$MINER_DEMO_FLAG" = true ]; then
-    DEMO_INTENT=true
-else
-    DEMO_INTENT=false
+if [ "$FLAG_DEMO" != true ] && [ "$MINER_DEMO_FLAG" = true ]; then
+    export MINER_DEMO
+    exec bash "$0" --demo
 fi
 
 if [ -f .env ] && [ -z "${MINER_TEMPLATE:-}" ]; then
@@ -520,22 +633,11 @@ fi
 ensure_runtime_assets
 maybe_prompt_ai_assistant
 
-# Portable lowercase (works on macOS bash 3.2 — ${VAR,,} is bash 4+).
-# Accepted values match the Python miner's env parser (1|true|yes|on) so
-# both layers agree on what flips demo mode.
-MINER_DEMO_LC="$(printf '%s' "${MINER_DEMO:-}" | tr '[:upper:]' '[:lower:]')"
-case "$MINER_DEMO_LC" in 1|true|yes|on) MINER_DEMO_FLAG=true ;; *) MINER_DEMO_FLAG=false ;; esac
-if [ "$FLAG_DEMO" = true ] || [ "$MINER_DEMO_FLAG" = true ]; then
-    echo -e "${YELLOW}Starting Minos Miner (${MINER_TEMPLATE:-gatk}) in DEMO MODE...${NC}"
-    echo -e "${YELLOW}  - no wallet required, no chain connection${NC}"
-    echo -e "${YELLOW}  - routes to platform /v2/demo/* sandbox${NC}"
-    echo -e "${YELLOW}  - submissions are accepted but not scored, no TAO earned${NC}"
-    python -m neurons.miner --demo
-else
-    echo -e "${GREEN}Starting Minos Miner (${MINER_TEMPLATE:-gatk})...${NC}"
-    python -m neurons.miner \
-        --netuid ${NETUID:-107} \
-        --subtensor.network finney \
-        --wallet.name ${WALLET_NAME:-default} \
-        --wallet.hotkey ${WALLET_HOTKEY:-default}
-fi
+# Live mining. (Demo intent — --demo / MINER_DEMO — is handled by the
+# practice/demo scoring fast-path above, which exec's and never returns here.)
+echo -e "${GREEN}Starting Minos Miner (${MINER_TEMPLATE:-gatk})...${NC}"
+python -m neurons.miner \
+    --netuid ${NETUID:-107} \
+    --subtensor.network finney \
+    --wallet.name ${WALLET_NAME:-default} \
+    --wallet.hotkey ${WALLET_HOTKEY:-default}

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -17,10 +17,10 @@ except ImportError:
     HAS_BOTO3 = False
     logger.warning("boto3 not installed - S3 features disabled")
 
-# Cloudflare R2's public bucket (used as the reference-data origin) returns 403
-# Forbidden for the default `Python-urllib/*` User-Agent as part of its bot
-# protection. Set an explicit UA on every request so the redirect from
-# api.theminos.ai/reference/* lands cleanly on the R2 origin.
+# The public reference-data origin (behind api.theminos.ai/reference/*) returns
+# 403 Forbidden for the default `Python-urllib/*` User-Agent as part of its bot
+# protection. Set an explicit UA on every request so those downloads (and the
+# presigned URLs served for BAMs) land cleanly instead of being bot-blocked.
 USER_AGENT = "minos-installer/0.1 (+https://github.com/minos-protocol/minos_subnet)"
 
 try:

--- a/utils/platform_client.py
+++ b/utils/platform_client.py
@@ -322,6 +322,81 @@ class MinerPlatformClient(PlatformClient):
 
         return await retry_async(_do_request, max_retries=2)
 
+    # =========================================================================
+    # Practice-mode API (self-scoring sandbox). Separate namespace from the
+    # live round + demo paths. The platform 404s these unless practice mode
+    # is enabled server-side, so they degrade cleanly on a deployment that
+    # hasn't turned the feature on. Uses the same v2 canonical auth as the
+    # other miner calls; an ephemeral keypair is accepted (like demo).
+    # =========================================================================
+
+    async def list_practice_samples(self) -> Dict[str, Any]:
+        """Fetch the practice-sample menu (metadata only, no file URLs).
+
+        Returns:
+            Dict with a "samples" list, each entry containing sample_id,
+            chromosome, region, num_mutations.
+
+        Raises:
+            PlatformClientError on 404 (practice mode not enabled on this
+            deployment) or any non-200.
+        """
+        path = "/v2/practice/list-samples"
+
+        async def _do_request():
+            body = self._auth_body("POST", path, hotkey=self.keypair.ss58_address)
+            async with self._get_client() as client:
+                response = await client.post(path, json=body, headers=self._AUTH_HEADERS)
+                if response.status_code == 401:
+                    raise AuthenticationError("Invalid signature")
+                if response.status_code == 404:
+                    raise PlatformClientError(
+                        "Practice mode is not enabled on this platform deployment."
+                    )
+                if response.status_code != 200:
+                    raise PlatformClientError(f"Failed to list practice samples: {response.text}")
+                return response.json()
+
+        return await retry_async(_do_request, max_retries=2)
+
+    async def get_practice_sample(self, sample_id: str) -> Dict[str, Any]:
+        """Fetch one practice sample's presigned BAM + truth + mutations URLs.
+
+        Args:
+            sample_id: id from list_practice_samples().
+
+        Returns:
+            Dict with metadata + presigned URLs (bam_presigned_url and
+            _backup, truth_vcf_presigned_url*, mutations_vcf_presigned_url*),
+            plus bam_sha256 / truth_vcf_sha256 when configured.
+
+        Raises:
+            PlatformClientError on 404 (unknown sample_id, or practice mode
+            not enabled) or any non-200.
+        """
+        path = "/v2/practice/get-sample"
+
+        async def _do_request():
+            body = self._auth_body(
+                "POST", path,
+                hotkey=self.keypair.ss58_address,
+                sample_id=sample_id,
+            )
+            async with self._get_client() as client:
+                response = await client.post(path, json=body, headers=self._AUTH_HEADERS)
+                if response.status_code == 401:
+                    raise AuthenticationError("Invalid signature")
+                if response.status_code == 404:
+                    raise PlatformClientError(
+                        f"Practice sample '{sample_id}' not found "
+                        "(unknown id, or practice mode not enabled)."
+                    )
+                if response.status_code != 200:
+                    raise PlatformClientError(f"Failed to get practice sample: {response.text}")
+                return response.json()
+
+        return await retry_async(_do_request, max_retries=2)
+
 
 class ValidatorPlatformClient(PlatformClient):
     """Platform client for validators."""


### PR DESCRIPTION
## Summary

Miners can now self-score their config offline against the same scorer
validators use — no chain, no wallet, no live round involved. This turns
`--demo` from a pipeline smoke test into a real scoring run and adds a
full practice mode for iterating on configs before going live.

## What's new

| Command | What it does |
|---|---|
| `--practice` | Pick a fully-answered chr20/chr21 sample, run your config, and see the exact score a validator would give it. Score against any sample; compare configs before going live. |
| `--demo` | A one-shot, walletless onboarding run — the same self-scorer pinned to a single fixed sample, so a new operator gets a score in one command. |
| `--score` | Self-score against a local BAM + truth you already have. |

All three run before the full miner (no subtensor/metagraph) and reuse
the validator's `HappyScorer` + `AdvancedScorer`, so the printed score
matches what a validator would record.

## Also in this PR

- **`platform_client`**: `list_practice_samples` / `get_practice_sample`.
- **`start-miner.sh`**: `--practice` / `--demo` fast-path (skips wallet
  and chain, fetches the RTG SDF needed for scoring). A persisted
  `MINER_DEMO=true` no longer falls through to live mining; `--demo`
  scopes the reference download to chr20.
- **`scripts/demo.sh`**: runs the one-shot scorer in the foreground
  (dropped the old background-poll/log-grep wrapper).
- **`pm2-miner.sh`**: PM2 is for the live miner only — demo/practice are
  one-shot and run in the foreground.
- **Installer**: `requirements.txt` / `install.sh` now install the CPU
  build of PyTorch by default (~200 MB instead of ~2 GB).
- **Robustness**: coalesce presigned URLs so a backup-only round no
  longer crashes on a missing primary URL; validate the `--region`
  format before use.

## Files changed

`11 files, +1300 / −275` — miner startup + scoring path, platform
client, installer, and docs.

## Testing

- `--practice` / `--demo` / `--score` dispatch verified; scoring reuses
  the validator scorer (parity with the record/discard guard confirmed).
- Reference-scope, wallet-fallthrough, and installer behaviors checked.
- Docs (README, tuning guide, demo script) updated to match.

## Notes for reviewers

- `--demo` and `--practice` are one-shot foreground tools — not meant to
  run under PM2.
- The legacy `PLATFORM_MODE=demo` deployment path is unchanged.